### PR TITLE
fix: dashboard status display, version consistency, and build metadata

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,4 +1,10 @@
 const path = require('path')
+const { execSync } = require('child_process')
+
+let gitCommit = 'unknown'
+try {
+  gitCommit = execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim()
+} catch { /* not a git repo or git not available */ }
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -21,7 +27,12 @@ const nextConfig = {
       { source: '/raw.txt', destination: '/api/file/raw' },
       { source: '/health', destination: '/api/health' }
     ]
-  }
+  },
+  // 注入构建时元数据，用于运行时展示版本和 commit
+  env: {
+    NEXT_PUBLIC_GIT_COMMIT: gitCommit,
+    NEXT_PUBLIC_BUILD_TIME: new Date().toISOString(),
+  },
 }
 
 module.exports = nextConfig

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -161,7 +161,14 @@ export default function Dashboard({ initialStatus = null, initialError = null }:
       <footer className="text-center pt-4 pb-8">
         <p className="text-xs" style={{ color: 'var(--muted-foreground)' }}>
           Subscription Garden · Next.js SSR · Botanical Garden Theme
+          {status?.version && <> · v{status.version}</>}
         </p>
+        {status?.gitCommit && (
+          <p className="text-[10px] mt-1 font-mono" style={{ color: 'var(--muted-foreground)' }}>
+            {status.gitCommit}
+            {status.buildTime && <> · built {new Date(status.buildTime).toLocaleDateString('zh-CN')}</>}
+          </p>
+        )}
       </footer>
     </div>
   )

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -38,6 +38,8 @@ export interface ApiStatus {
   uptime: number;
   version: string;
   mihomoVersion?: string;
+  gitCommit?: string;
+  buildTime?: string;
 }
 
 export interface UpdateResult {
@@ -106,7 +108,8 @@ class ApiService {
   // 获取API状态
   async getStatus(): Promise<ApiStatus> {
     try {
-      return await apiClient.get('api/status').json<ApiStatus>();
+      const response = await apiClient.get('api/status').json<ApiResponse<ApiStatus>>();
+      return response.data as ApiStatus;
     } catch (error) {
       return this.handleError(error);
     }
@@ -115,7 +118,8 @@ class ApiService {
   // 更新订阅
   async updateSubscription(): Promise<UpdateResult> {
     try {
-      return await apiClient.get('api/update').json<UpdateResult>();
+      const response = await apiClient.get('api/update').json<ApiResponse<UpdateResult>>();
+      return response.data as UpdateResult;
     } catch (error) {
       return this.handleError(error);
     }

--- a/frontend/src/pages/api/health.ts
+++ b/frontend/src/pages/api/health.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { VERSION } from '@/server/version';
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
@@ -7,7 +8,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
       timestamp: new Date().toISOString(),
       uptime: process.uptime(),
       memory: process.memoryUsage(),
-      version: '1.0.0',
+      version: VERSION,
     });
   } catch (error: any) {
     res.status(503).json({ status: 'unhealthy', error: error.message, timestamp: new Date().toISOString() });

--- a/frontend/src/server/config/index.ts
+++ b/frontend/src/server/config/index.ts
@@ -1,6 +1,7 @@
 import { Config } from '../types';
 import * as path from 'path';
 import { yamlService } from '../services/yamlService';
+import { VERSION } from '../version';
 
 // 直接导出 yamlService 实例，供其他模块使用
 export { yamlService };
@@ -19,7 +20,7 @@ export const getAppEnvironment = (): string => {
 // 获取应用版本
 export const getAppVersion = (): string => {
     const fullConfig = yamlService.getFullConfig();
-    return fullConfig?.app?.version || '1.0.0';
+    return fullConfig?.app?.version || VERSION;
 };
 
 // 获取日志级别
@@ -59,7 +60,7 @@ export const getFrontendConfig = () => {
         return {
             app: {
                 name: 'subscription-api-ts',
-                version: '1.0.0',
+                version: VERSION,
                 environment: 'production'
             },
             network: {

--- a/frontend/src/server/services/subscriptionService.ts
+++ b/frontend/src/server/services/subscriptionService.ts
@@ -1,11 +1,12 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import { UpdateResult } from '../types';
+import { StatusInfo, UpdateResult } from '../types';
 import { config } from '../config';
 import { logger } from '../utils/logger';
 import { SingBoxService } from './singBoxService';
 import { MihomoService } from './mihomoService';
 import { YamlService } from './yamlService';
+import { VERSION, GIT_COMMIT, BUILD_TIME } from '../version';
 
 export class SubscriptionService {
     private static instance: SubscriptionService;
@@ -200,25 +201,27 @@ export class SubscriptionService {
     /**
      * 获取订阅状态信息
      */
-    async getStatus(): Promise<any> {
+    async getStatus(): Promise<StatusInfo> {
         const subscriptionFile = path.join(config.staticDir, 'subscription.txt');
         const clashFile = path.join(config.staticDir, config.clashFilename);
         const rawFile = path.join(config.staticDir, 'raw.txt');
 
-        const status = {
+        const status: StatusInfo = {
             subscriptionExists: await fs.pathExists(subscriptionFile),
             clashExists: await fs.pathExists(clashFile),
             rawExists: await fs.pathExists(rawFile),
             mihomoAvailable: await this.mihomoService.checkHealth(),
             singBoxAccessible: await this.singBoxService.checkSingBoxAvailable(),
             uptime: process.uptime(),
-            version: '2.0.0'
+            version: VERSION,
+            gitCommit: GIT_COMMIT,
+            buildTime: BUILD_TIME,
         };
 
         // 获取 mihomo 版本信息
         try {
             const mihomoVersion = await this.mihomoService.getVersion();
-            (status as any).mihomoVersion = mihomoVersion?.version || 'unknown';
+            status.mihomoVersion = mihomoVersion?.version || 'unknown';
         } catch (error) {
             logger.warn('获取 mihomo 版本失败:', error);
         }
@@ -226,20 +229,20 @@ export class SubscriptionService {
         // 获取文件信息
         if (status.subscriptionExists) {
             const stats = await fs.stat(subscriptionFile);
-            (status as any).subscriptionLastUpdated = stats.mtime.toISOString();
-            (status as any).subscriptionSize = stats.size;
+            status.subscriptionLastUpdated = stats.mtime.toISOString();
+            status.subscriptionSize = stats.size;
         }
 
         if (status.clashExists) {
             const stats = await fs.stat(clashFile);
-            (status as any).clashLastUpdated = stats.mtime.toISOString();
-            (status as any).clashSize = stats.size;
+            status.clashLastUpdated = stats.mtime.toISOString();
+            status.clashSize = stats.size;
         }
 
         if (status.rawExists) {
             const content = await fs.readFile(rawFile, 'utf8');
             const lines = content.split('\n').filter(line => line.trim());
-            (status as any).nodesCount = lines.length;
+            status.nodesCount = lines.length;
         }
 
         return status;

--- a/frontend/src/server/types/index.ts
+++ b/frontend/src/server/types/index.ts
@@ -42,6 +42,8 @@ export interface StatusInfo {
     uptime: number;
     version: string;
     mihomoVersion?: string;
+    gitCommit?: string;
+    buildTime?: string;
 }
 
 export interface ApiResponse<T = any> {

--- a/frontend/src/server/version.ts
+++ b/frontend/src/server/version.ts
@@ -1,0 +1,11 @@
+// Centralized version and build metadata
+// Single source of truth for the application version
+import pkg from '../../../package.json';
+
+export const VERSION: string = pkg.version;
+
+export const GIT_COMMIT: string =
+  process.env.NEXT_PUBLIC_GIT_COMMIT || 'unknown';
+
+export const BUILD_TIME: string =
+  process.env.NEXT_PUBLIC_BUILD_TIME || 'unknown';


### PR DESCRIPTION
## Bug fixes

### 1. CRITICAL: Dashboard shows wrong states after 30s poll

**Root cause**: API routes return `{ success, data: <payload>, timestamp }`, but `api.ts` methods `getStatus()` and `updateSubscription()` deserialized the full response as the payload type without unwrapping the `data` field. After the first 30-second client poll, all boolean fields (`clashExists`, `subscriptionExists`, etc.) became `undefined` (falsy), causing the dashboard to show everything as "未生成" / 0 nodes.

**Fix**: `getStatus()` and `updateSubscription()` now unwrap `response.data`, consistent with `getConfigs()` which already worked correctly.

### 2. Version consistency

Three different hardcoded versions existed across the codebase:
- `subscriptionService.ts`: `'2.0.0'`
- `health.ts`: `'1.0.0'`
- `config/index.ts`: `'1.0.0'`

**Fix**: Created `server/version.ts` as single source of truth, importing from `package.json`. All consumers now use `VERSION`.

### 3. Build metadata (deploy verification)

**New**: `next.config.js` injects `NEXT_PUBLIC_GIT_COMMIT` and `NEXT_PUBLIC_BUILD_TIME` at build time. Visible in:
- `/api/status` response (`gitCommit`, `buildTime` fields)
- Dashboard footer (commit hash + build date)
- Type-safe via `StatusInfo` and `ApiStatus` interfaces

### 4. Type safety

`getStatus()` return type changed from `Promise<any>` to `Promise<StatusInfo>`, removing all `(status as any)` casts.

## Verification

After deployment:
```bash
# Dashboard polling works — clashExists should be true
curl -s http://127.0.0.1:3001/api/status | jq '.data.clashExists'
# Expected: true

# Version consistent across all endpoints
curl -s http://127.0.0.1:3001/api/status | jq '.data.version'
curl -s http://127.0.0.1:3001/api/health | jq '.version'
# Both should match package.json

# Git commit visible
curl -s http://127.0.0.1:3001/api/status | jq '.data.gitCommit'
# Expected: short hash like "2ba340f"
```

Co-Authored-By: Claude <noreply@anthropic.com>