### PR TITLE
feat: AI service rules + backend-down banner for static preview

### DIFF
--- a/packages/core/src/kernels/mihomoAdapter.ts
+++ b/packages/core/src/kernels/mihomoAdapter.ts
@@ -68,9 +68,43 @@ export class MihomoAdapter {
       { name: '♻️ 自动选择', type: 'url-test', proxies: names, url: 'http://www.gstatic.com/generate_204', interval: 300 },
       { name: '🔯 故障转移', type: 'fallback', proxies: names, url: 'http://www.gstatic.com/generate_204', interval: 300 },
       { name: '🔮 负载均衡', type: 'load-balance', proxies: names, url: 'http://www.gstatic.com/generate_204', interval: 300 },
-      { name: '🎯 全球直连', type: 'select', proxies: ['DIRECT'] },
-      { name: '🐟 漏网之鱼', type: 'select', proxies: ['🚀 节点选择', '🎯 全球直连', '♻️ 自动选择'] },
-    ], rules: ['DOMAIN-SUFFIX,local,DIRECT', 'IP-CIDR,127.0.0.0/8,DIRECT', 'IP-CIDR,172.16.0.0/12,DIRECT', 'IP-CIDR,192.168.0.0/16,DIRECT', 'IP-CIDR,10.0.0.0/8,DIRECT', 'IP-CIDR,17.0.0.0/8,DIRECT', 'IP-CIDR,100.64.0.0/10,DIRECT', 'DOMAIN-SUFFIX,cn,DIRECT', 'MATCH,🐟 漏网之鱼'] }, { lineWidth: 0 });
+   { name: '🎯 全球直连', type: 'select', proxies: ['DIRECT'] },
+   { name: '🐟 漏网之鱼', type: 'select', proxies: ['🚀 节点选择', '🎯 全球直连', '♻️ 自动选择'] },
+    { name: '🤖 AI服务', type: 'select', proxies: ['🚀 节点选择', '🎯 全球直连', '♻️ 自动选择'] },
+  ], rules: [
+    'DOMAIN-SUFFIX,local,DIRECT',
+    'IP-CIDR,127.0.0.0/8,DIRECT',
+    'IP-CIDR,172.16.0.0/12,DIRECT',
+    'IP-CIDR,192.168.0.0/16,DIRECT',
+    'IP-CIDR,10.0.0.0/8,DIRECT',
+    'IP-CIDR,17.0.0.0/8,DIRECT',
+    'IP-CIDR,100.64.0.0/10,DIRECT',
+    'DOMAIN-SUFFIX,cn,DIRECT',
+    // OpenAI
+    'DOMAIN-SUFFIX,openai.com,🤖 AI服务',
+    'DOMAIN-SUFFIX,chatgpt.com,🤖 AI服务',
+    'DOMAIN-SUFFIX,oaistatic.com,🤖 AI服务',
+    'DOMAIN-SUFFIX,oaiusercontent.com,🤖 AI服务',
+    // Anthropic
+    'DOMAIN-SUFFIX,anthropic.com,🤖 AI服务',
+    'DOMAIN-SUFFIX,claude.ai,🤖 AI服务',
+    // Google AI
+    'DOMAIN-SUFFIX,gemini.google.com,🤖 AI服务',
+    'DOMAIN-SUFFIX,ai.google.dev,🤖 AI服务',
+    'DOMAIN-SUFFIX,generativeai.google.com,🤖 AI服务',
+    // GitHub Copilot
+    'DOMAIN-SUFFIX,githubcopilot.com,🤖 AI服务',
+    'DOMAIN-SUFFIX,copilot.github.com,🤖 AI服务',
+    // DeepSeek
+    'DOMAIN-SUFFIX,deepseek.com,🤖 AI服务',
+    // Groq
+    'DOMAIN-SUFFIX,groq.com,🤖 AI服务',
+    // Perplexity
+    'DOMAIN-SUFFIX,perplexity.ai,🤖 AI服务',
+    // Mistral
+    'DOMAIN-SUFFIX,mistral.ai,🤖 AI服务',
+    'MATCH,🐟 漏网之鱼'
+  ] }, { lineWidth: 0 });
     const output = `# Clash 配置文件\n# 由 miobridge 生成，mihomo 可用时自动验证\n# 生成时间: ${new Date().toISOString()}\n# 节点数量: ${proxies.length}\n\n${yaml}`;
     await this.validate(output);
     return output;

--- a/packages/frontend/src/components/Dashboard.tsx
+++ b/packages/frontend/src/components/Dashboard.tsx
@@ -45,6 +45,7 @@ function formatBytes(value?: number) {
 }
 
 export default function Dashboard({ initialCluster = null, initialStatus = null, initialError = null }: DashboardProps) {
+  const { backendReachable } = useAppContext()
   const [status, setStatus] = useState(initialStatus)
   const [cluster, setCluster] = useState(initialCluster)
   const [updateResult, setUpdateResult] = useState<UpdateResult | null>(null)
@@ -126,6 +127,18 @@ export default function Dashboard({ initialCluster = null, initialStatus = null,
         </>
       )}
     >
+      {backendReachable === false ? (
+        <Alert variant="destructive" className="mb-6 flex gap-3">
+          <Icon icon="ph:warning-circle-light" className="mt-0.5 h-5 w-5 flex-shrink-0" />
+          <div>
+            <AlertTitle>仪表盘后端未运行</AlertTitle>
+            <AlertDescription>
+              当前为静态预览。请通过 CLI 启动完整仪表盘：<code className="rounded bg-destructive/10 px-1.5 py-0.5 text-sm">miobridge dashboard start</code>
+            </AlertDescription>
+          </div>
+        </Alert>
+      ) : null}
+
       {error ? (
         <Alert variant="destructive" className="mb-6 flex gap-3">
           <Icon icon="ph:warning-circle-light" className="mt-0.5 h-5 w-5 flex-shrink-0" />

--- a/packages/frontend/src/context/AppContext.tsx
+++ b/packages/frontend/src/context/AppContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useEffect, useState } from 'react'
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react'
 import type { UpdateResult } from '@/lib/api'
 
 interface AppContextValue {
@@ -11,6 +11,7 @@ interface AppContextValue {
   setSidebarCollapsed: (v: boolean) => void
   mobileDrawerOpen: boolean
   setMobileDrawerOpen: (v: boolean) => void
+  backendReachable: boolean | null
 }
 
 const AppContext = createContext<AppContextValue | null>(null)
@@ -20,6 +21,18 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   const [convertModalOpen, setConvertModalOpen] = useState(false)
   const [sidebarCollapsed, setSidebarCollapsedState] = useState(false)
   const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false)
+  const [backendReachable, setBackendReachable] = useState<boolean | null>(null)
+  const healthCheckedRef = useRef(false)
+
+  useEffect(() => {
+    if (healthCheckedRef.current) return
+    healthCheckedRef.current = true
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), 5000)
+    fetch('/health', { signal: controller.signal })
+      .then(res => { setBackendReachable(res.ok); clearTimeout(timer) })
+      .catch(() => { setBackendReachable(false); clearTimeout(timer) })
+  }, [])
 
   useEffect(() => {
     try {
@@ -42,6 +55,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       convertModalOpen, openConvertModal, closeConvertModal,
       sidebarCollapsed, setSidebarCollapsed,
       mobileDrawerOpen, setMobileDrawerOpen,
+      backendReachable,
     }}>
       {children}
     </AppContext.Provider>

--- a/packages/frontend/src/server/services/mihomoService.ts
+++ b/packages/frontend/src/server/services/mihomoService.ts
@@ -721,8 +721,13 @@ export class MihomoService {
                     type: 'select',
                     proxies: ['DIRECT']
                 },
+               {
+                   name: '🐟 漏网之鱼',
+                   type: 'select',
+                   proxies: ['🚀 节点选择', '🎯 全球直连', '♻️ 自动选择']
+                },
                 {
-                    name: '🐟 漏网之鱼',
+                    name: '🤖 AI服务',
                     type: 'select',
                     proxies: ['🚀 节点选择', '🎯 全球直连', '♻️ 自动选择']
                 }
@@ -736,6 +741,29 @@ export class MihomoService {
                 'IP-CIDR,17.0.0.0/8,DIRECT',
                 'IP-CIDR,100.64.0.0/10,DIRECT',
                 'DOMAIN-SUFFIX,cn,DIRECT',
+                // OpenAI
+                'DOMAIN-SUFFIX,openai.com,🤖 AI服务',
+                'DOMAIN-SUFFIX,chatgpt.com,🤖 AI服务',
+                'DOMAIN-SUFFIX,oaistatic.com,🤖 AI服务',
+                'DOMAIN-SUFFIX,oaiusercontent.com,🤖 AI服务',
+                // Anthropic
+                'DOMAIN-SUFFIX,anthropic.com,🤖 AI服务',
+                'DOMAIN-SUFFIX,claude.ai,🤖 AI服务',
+                // Google AI
+                'DOMAIN-SUFFIX,gemini.google.com,🤖 AI服务',
+                'DOMAIN-SUFFIX,ai.google.dev,🤖 AI服务',
+                'DOMAIN-SUFFIX,generativeai.google.com,🤖 AI服务',
+                // GitHub Copilot
+                'DOMAIN-SUFFIX,githubcopilot.com,🤖 AI服务',
+                'DOMAIN-SUFFIX,copilot.github.com,🤖 AI服务',
+                // DeepSeek
+                'DOMAIN-SUFFIX,deepseek.com,🤖 AI服务',
+                // Groq
+                'DOMAIN-SUFFIX,groq.com,🤖 AI服务',
+                // Perplexity
+                'DOMAIN-SUFFIX,perplexity.ai,🤖 AI服务',
+                // Mistral
+                'DOMAIN-SUFFIX,mistral.ai,🤖 AI服务',
                 'MATCH,🐟 漏网之鱼'
             ]
         };


### PR DESCRIPTION
## Changes

1. **🤖 AI 服务规则** — 在默认 Clash 配置中添加 AI 服务分流规则
   - OpenAI / ChatGPT: openai.com, chatgpt.com, oaistatic.com, oaiusercontent.com
   - Anthropic / Claude: anthropic.com, claude.ai
   - Google AI: gemini.google.com, ai.google.dev, generativeai.google.com
   - GitHub Copilot: githubcopilot.com, copilot.github.com
   - DeepSeek / Groq / Perplexity / Mistral
   - 新增 🤖 AI服务 proxy-group (select 类型)

2. **静态预览后端检测** — Vercel 部署的 SPA 检测后端是否可达
   - AppContext 启动时请求 /health
   - 后端不可达时 Dashboard 显示仪表盘后端未运行提示
   - 避免用户在 Vercel 预览页看到节点操作失败等误导性错误