### PR TITLE
fix CLI release installation and purge uninstall

### DIFF
--- a/.Codex/memory/bug-fixes.md
+++ b/.Codex/memory/bug-fixes.md
@@ -7,6 +7,12 @@ metadata:
 
 # Bug Fixes
 
+- 2026-07-14: Managed dependencies and self-upgrade archives use `node:zlib`;
+  release CLIs no longer depend on the unavailable `DecompressionStream` global.
+- 2026-07-14: CLI artifact downloads retry transient network and timeout failures
+  with bounded per-attempt timeouts before setup or upgrade fails.
+- 2026-07-14: `uninstall --purge` removes the CLI and complete runtime directory;
+  plain `uninstall` remains the safe configuration-preserving default.
 - 2026-07-14: The one-line installer resolves and verifies a release without
   relying on its source path, then atomically installs both the CLI and dashboard;
   piped execution never looks for `/home/<user>/manage.sh`.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ SPA and API routes. It needs no Node.js runtime or separate web server.
 ```bash
 miobridge dashboard stop
 miobridge uninstall           # preserve config, data, logs, and backups
+miobridge uninstall --purge   # also remove config, data, and managed dependencies
 ```
 
 ## Development

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,6 +35,7 @@ miobridge --help              # 列出所有命令
 ```bash
 miobridge dashboard stop
 miobridge uninstall           # 保留配置、数据、日志和备份
+miobridge uninstall --purge   # 同时删除配置、数据及托管依赖
 ```
 
 ## 开发

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -62,6 +62,13 @@ miobridge uninstall
 This preserves `~/.config/miobridge`, including `config.yaml`, data, generated
 subscriptions, logs, and backups.
 
+To remove the CLI and the complete MioBridge runtime directory, including
+configuration, generated data, dashboard assets, and managed dependencies:
+
+```bash
+miobridge uninstall --purge
+```
+
 ## Managed dependencies
 
 `miobridge setup` reports each required tool as `configured`, `managed`,

--- a/docs/CLI.zh-CN.md
+++ b/docs/CLI.zh-CN.md
@@ -59,6 +59,12 @@ miobridge uninstall
 此操作保留 `~/.config/miobridge`，包括 `config.yaml`、数据、订阅产物、日志与
 备份。
 
+如需同时删除 CLI 和整个 MioBridge 运行目录（配置、生成数据、仪表盘及托管依赖）：
+
+```bash
+miobridge uninstall --purge
+```
+
 ## 托管依赖
 
 `miobridge setup` 会将每个工具标记为 `configured`、`managed`、`PATH` 或

--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -22,7 +22,7 @@ export interface CliDependencies {
   readonly setup?: Pick<DependencySetupService, 'run'>;
   readonly maintenance?: {
     upgrade(): Promise<string>;
-    uninstall(): Promise<string>;
+    uninstall(purge: boolean): Promise<string>;
   };
   readonly dashboard?: {
     foreground(): Promise<{ readonly exitCode: number; readonly healthUrl: string }>;
@@ -36,7 +36,7 @@ type ParsedCommand =
   | { readonly kind: 'update' }
   | { readonly kind: 'setup'; readonly assumeYes: boolean }
   | { readonly kind: 'upgrade' }
-  | { readonly kind: 'uninstall' }
+  | { readonly kind: 'uninstall'; readonly purge: boolean }
   | { readonly kind: 'dashboard-foreground' }
   | { readonly kind: 'dashboard-daemon'; readonly action: DashboardDaemonAction; readonly json: boolean }
   | { readonly kind: 'status'; readonly json: boolean };
@@ -48,7 +48,8 @@ Usage: miobridge <command> [options]
 Commands:
   setup [--yes]   Discover and install managed dependencies
   upgrade         Upgrade this CLI to the latest verified release
-  uninstall       Remove this CLI; preserve configuration and data
+  uninstall [--purge]
+                  Remove this CLI; --purge also removes configuration and data
   update          Generate subscription artifacts
   status [--json] Show headless runtime status
   dashboard foreground
@@ -78,9 +79,14 @@ export function parseCommand(args: readonly string[]): ParsedCommand {
     if (args.length === 2 && (args[1] === '--yes' || args[1] === '-y')) return { kind: 'setup', assumeYes: true };
     throw new Error(`Unexpected argument: ${args[1]}`);
   }
-  if (args[0] === 'upgrade' || args[0] === 'uninstall') {
+  if (args[0] === 'upgrade') {
     if (args.length > 1) throw new Error(`Unexpected argument: ${args[1]}`);
-    return { kind: args[0] };
+    return { kind: 'upgrade' };
+  }
+  if (args[0] === 'uninstall') {
+    if (args.length === 1) return { kind: 'uninstall', purge: false };
+    if (args.length === 2 && args[1] === '--purge') return { kind: 'uninstall', purge: true };
+    throw new Error(`Unexpected argument: ${args[1]}`);
   }
   if (args[0] === 'status') {
     if (args.length === 1) return { kind: 'status', json: false };
@@ -141,9 +147,14 @@ export async function runCli(args: readonly string[], dependencies: CliDependenc
       dependencies.output.stdout(formatSetupStatus(await dependencies.setup.run({ assumeYes: command.assumeYes })));
       return 0;
     }
-    if (command.kind === 'upgrade' || command.kind === 'uninstall') {
+    if (command.kind === 'upgrade') {
       if (!dependencies.maintenance) throw new Error('CLI maintenance adapters are unavailable');
-      dependencies.output.stdout(await dependencies.maintenance[command.kind]());
+      dependencies.output.stdout(await dependencies.maintenance.upgrade());
+      return 0;
+    }
+    if (command.kind === 'uninstall') {
+      if (!dependencies.maintenance) throw new Error('CLI maintenance adapters are unavailable');
+      dependencies.output.stdout(await dependencies.maintenance.uninstall(command.purge));
       return 0;
     }
     if (command.kind === 'dashboard-foreground') {

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -20,6 +20,7 @@ const maintenance = new SelfMaintenanceService({
   currentVersion: CLI_VERSION,
   executablePath: process.execPath,
   dashboardPath: `${composition.paths.distDir}/dashboard`,
+  configDir: composition.paths.baseDir,
   adapters: createNodeSelfMaintenanceAdapters(),
   ...(process.env.MIOBRIDGE_REPOSITORY ? { repository: process.env.MIOBRIDGE_REPOSITORY } : {}),
   ...(process.env.MIOBRIDGE_VERSION ? { targetVersion: process.env.MIOBRIDGE_VERSION } : {}),
@@ -34,10 +35,10 @@ const exitCode = await runCli(process.argv.slice(2), {
   } }),
   maintenance: {
     upgrade: () => maintenance.upgrade(),
-    async uninstall() {
+    async uninstall(purge) {
       const status = await dashboardDaemon.status();
       if (status.state !== 'unsupported' && (status.active || status.enabled)) await dashboardDaemon.stop();
-      return maintenance.uninstall();
+      return maintenance.uninstall({ purge });
     },
   },
   dashboard: {

--- a/packages/cli/src/platform/download.ts
+++ b/packages/cli/src/platform/download.ts
@@ -1,0 +1,29 @@
+export interface DownloadOptions {
+  readonly attempts?: number;
+  readonly timeoutMs?: number;
+  readonly retryDelayMs?: number;
+  readonly fetcher?: (input: string, init: RequestInit) => Promise<Response>;
+}
+
+const delay = (milliseconds: number) => new Promise(resolve => setTimeout(resolve, milliseconds));
+
+export async function downloadBytes(url: string, options: DownloadOptions = {}): Promise<Uint8Array> {
+  const attempts = options.attempts ?? 3;
+  const timeoutMs = options.timeoutMs ?? 120_000;
+  const retryDelayMs = options.retryDelayMs ?? 1_000;
+  const fetcher = options.fetcher ?? fetch;
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const response = await fetcher(url, { redirect: 'follow', signal: AbortSignal.timeout(timeoutMs) });
+      if (!response.ok) throw new Error(`Download failed with HTTP ${response.status}`);
+      return new Uint8Array(await response.arrayBuffer());
+    } catch (error) {
+      lastError = error;
+      if (attempt < attempts) await delay(retryDelayMs * attempt);
+    }
+  }
+
+  throw lastError;
+}

--- a/packages/cli/src/self/nodeAdapters.ts
+++ b/packages/cli/src/self/nodeAdapters.ts
@@ -5,14 +5,17 @@ import { chmod, copyFile, mkdir, open, readFile, rename, rm, writeFile } from 'n
 import { arch, platform } from 'node:os';
 import { dirname, join } from 'node:path';
 import { promisify } from 'node:util';
+import { gunzip as gunzipCallback } from 'node:zlib';
 import { detectLinuxPlatform } from '../platform/linux.js';
+import { downloadBytes } from '../platform/download.js';
 import type { SelfMaintenanceAdapters } from './service.js';
 
 const execFileAsync = promisify(execFile);
+const gunzipAsync = promisify(gunzipCallback);
 
 async function gunzip(data: Uint8Array): Promise<Uint8Array> {
-  const stream = new Blob([new Uint8Array(data).buffer]).stream().pipeThrough(new DecompressionStream('gzip'));
-  return new Uint8Array(await new Response(stream).arrayBuffer());
+  const input = Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+  return new Uint8Array(await gunzipAsync(input));
 }
 
 function tarString(data: Uint8Array, start: number, length: number): string {
@@ -135,11 +138,7 @@ export function createNodeSelfMaintenanceAdapters(): SelfMaintenanceAdapters {
       if (typeof body.tag_name !== 'string') throw new Error('Latest release response has no tag_name');
       return body.tag_name;
     },
-    async download(url) {
-      const response = await fetch(url, { redirect: 'follow', signal: AbortSignal.timeout(120_000) });
-      if (!response.ok) throw new Error(`Download failed with HTTP ${response.status}: ${new URL(url).pathname}`);
-      return new Uint8Array(await response.arrayBuffer());
-    },
+    download: downloadBytes,
     async sha256(data) { return createHash('sha256').update(data).digest('hex'); },
     extractTarGzipEntry,
     installAtomic,
@@ -149,6 +148,6 @@ export function createNodeSelfMaintenanceAdapters(): SelfMaintenanceAdapters {
       return result.stdout.trim();
     },
     async writeVersion(path, version) { await writeFile(path, `${version}\n`, { mode: 0o644 }); },
-    async remove(path) { await rm(path, { force: true }); },
+    async remove(path) { await rm(path, { recursive: true, force: true }); },
   };
 }

--- a/packages/cli/src/self/service.ts
+++ b/packages/cli/src/self/service.ts
@@ -22,6 +22,7 @@ export interface SelfMaintenanceOptions {
   readonly targetVersion?: string;
   readonly releaseBaseUrl?: string;
   readonly dashboardPath: string;
+  readonly configDir: string;
 }
 
 function normalizeVersion(version: string): string {
@@ -74,9 +75,13 @@ export class SelfMaintenanceService {
     return `MioBridge and dashboard upgraded from ${this.options.currentVersion} to ${version}.`;
   }
 
-  async uninstall(): Promise<string> {
+  async uninstall(options: { readonly purge?: boolean } = {}): Promise<string> {
     await this.options.adapters.remove(this.options.executablePath);
     await this.options.adapters.remove(join(dirname(this.options.executablePath), '.miobridge-cli-version'));
+    if (options.purge) {
+      await this.options.adapters.remove(this.options.configDir);
+      return 'MioBridge CLI, configuration, data, and managed dependencies removed.';
+    }
     return 'MioBridge CLI removed. Configuration and data were preserved.';
   }
 }

--- a/packages/cli/src/setup/nodeAdapters.ts
+++ b/packages/cli/src/setup/nodeAdapters.ts
@@ -6,10 +6,14 @@ import { dirname } from 'node:path';
 import { createInterface } from 'node:readline/promises';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { gunzip, inflateRaw } from 'node:zlib';
 import type { Artifact, SetupAdapters } from './types.js';
 import { detectLinuxPlatform } from '../platform/linux.js';
+import { downloadBytes } from '../platform/download.js';
 
 const execFileAsync = promisify(execFile);
+const gunzipAsync = promisify(gunzip);
+const inflateRawAsync = promisify(inflateRaw);
 
 async function command(path: string, args: readonly string[]): Promise<string> {
   const result = await execFileAsync(path, [...args], { timeout: 15_000, maxBuffer: 1024 * 1024 });
@@ -17,8 +21,9 @@ async function command(path: string, args: readonly string[]): Promise<string> {
 }
 
 async function decompress(data: Uint8Array, format: 'gzip' | 'deflate-raw'): Promise<Uint8Array> {
-  const stream = new Blob([new Uint8Array(data).buffer]).stream().pipeThrough(new DecompressionStream(format));
-  return new Uint8Array(await new Response(stream).arrayBuffer());
+  const input = Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+  const output = format === 'gzip' ? await gunzipAsync(input) : await inflateRawAsync(input);
+  return new Uint8Array(output);
 }
 
 async function extractZipEntry(data: Uint8Array, wanted: string): Promise<Uint8Array> {
@@ -72,11 +77,7 @@ export function createNodeSetupAdapters(): SetupAdapters {
       const prompt = createInterface({ input: process.stdin, output: process.stderr });
       try { return /^(?:y|yes)$/i.test((await prompt.question(`${message} [y/N] `)).trim()); } finally { prompt.close(); }
     },
-    async download(url) {
-      const response = await fetch(url, { redirect: 'follow', signal: AbortSignal.timeout(120_000) });
-      if (!response.ok) throw new Error(`Download failed with HTTP ${response.status}`);
-      return new Uint8Array(await response.arrayBuffer());
-    },
+    download: downloadBytes,
     async sha256(data) { return createHash('sha256').update(data).digest('hex'); },
     extract,
     async installAtomic(target, data, validate) {

--- a/packages/cli/test/command.test.ts
+++ b/packages/cli/test/command.test.ts
@@ -32,7 +32,8 @@ describe('CLI command contract', () => {
     expect(parseCommand(['setup'])).toEqual({ kind: 'setup', assumeYes: false });
     expect(parseCommand(['setup', '--yes'])).toEqual({ kind: 'setup', assumeYes: true });
     expect(parseCommand(['upgrade'])).toEqual({ kind: 'upgrade' });
-    expect(parseCommand(['uninstall'])).toEqual({ kind: 'uninstall' });
+    expect(parseCommand(['uninstall'])).toEqual({ kind: 'uninstall', purge: false });
+    expect(parseCommand(['uninstall', '--purge'])).toEqual({ kind: 'uninstall', purge: true });
     expect(parseCommand(['update'])).toEqual({ kind: 'update' });
     expect(parseCommand(['status'])).toEqual({ kind: 'status', json: false });
     expect(parseCommand(['status', '--json'])).toEqual({ kind: 'status', json: true });
@@ -79,7 +80,10 @@ describe('CLI command contract', () => {
     const maintenance = { upgrade: vi.fn(async () => 'upgraded'), uninstall: vi.fn(async () => 'removed') };
     expect(await runCli(['upgrade'], { ...run.dependencies, maintenance })).toBe(0);
     expect(await runCli(['uninstall'], { ...run.dependencies, maintenance })).toBe(0);
-    expect(run.stdout).toEqual(['upgraded', 'removed']);
+    expect(await runCli(['uninstall', '--purge'], { ...run.dependencies, maintenance })).toBe(0);
+    expect(maintenance.uninstall).toHaveBeenNthCalledWith(1, false);
+    expect(maintenance.uninstall).toHaveBeenNthCalledWith(2, true);
+    expect(run.stdout).toEqual(['upgraded', 'removed', 'removed']);
     expect(run.createCore).not.toHaveBeenCalled();
   });
 

--- a/packages/cli/test/release/release.test.ts
+++ b/packages/cli/test/release/release.test.ts
@@ -20,7 +20,7 @@ afterEach(() => {
   temporaryRoots.clear();
 });
 
-function fixture() {
+function fixture(options: { readonly setupFails?: boolean } = {}) {
   const dir = temporary('miobridge-release-test-');
   const binaries = join(dir, 'binaries');
   const release = join(dir, 'release');
@@ -32,7 +32,12 @@ function fixture() {
   writeFileSync(join(provider, 'artifact', 'index.html'), '<main>MioBridge</main>\n');
   for (const arch of ['x64', 'arm64']) {
     const file = join(binaries, arch);
-    writeFileSync(file, `#!/bin/sh\necho ${arch}-v1\n`);
+    writeFileSync(file, [
+      '#!/bin/sh',
+      ...(options.setupFails ? ['if [ "$1" = setup ]; then echo dependency-download-failed >&2; exit 1; fi'] : []),
+      `echo ${arch}-v1`,
+      '',
+    ].join('\n'));
     chmodSync(file, 0o755);
     const agent = join(binaries, `agent-${arch}`);
     writeFileSync(agent, '#!/bin/sh\necho 1.2.3\n');
@@ -159,6 +164,19 @@ describe('CLI release distribution', () => {
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain('checksum verification failed');
     expect(execFileSync(binary, { encoding: 'utf8' }).trim()).toBe('previous');
+  });
+
+  it('distinguishes a runtime setup failure from the completed CLI installation', () => {
+    const { dir, release } = fixture({ setupFails: true });
+    const installDir = join(dir, 'installed');
+    const result = spawnSync('sh', [installer, '--version', '1.2.3', '--base-url', `file://${release}`, '--install-dir', installDir], {
+      env: { ...process.env, HOME: dir, PATH: fakePlatform(dir, 'x86_64') }, encoding: 'utf8',
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('dependency-download-failed');
+    expect(result.stderr).toContain('MioBridge CLI 1.2.3 is installed, but runtime dependency setup failed.');
+    expect(result.stderr).toContain(`Retry with: ${join(installDir, 'miobridge')} setup --yes`);
+    expect(execFileSync(join(installDir, 'miobridge'), { encoding: 'utf8' }).trim()).toBe('x64-v1');
   });
 
   it('replaces only CLI-owned files and preserves user configuration', () => {

--- a/packages/cli/test/self-maintenance.test.ts
+++ b/packages/cli/test/self-maintenance.test.ts
@@ -31,7 +31,7 @@ function harness(overrides: Partial<SelfMaintenanceAdapters> = {}) {
     remove: async path => { removed.push(path); },
     ...overrides,
   };
-  const service = new SelfMaintenanceService({ currentVersion: '1.0.0', executablePath: '/home/user/.local/bin/miobridge', dashboardPath: '/home/user/.config/miobridge/dist/dashboard', adapters });
+  const service = new SelfMaintenanceService({ currentVersion: '1.0.0', executablePath: '/home/user/.local/bin/miobridge', dashboardPath: '/home/user/.config/miobridge/dist/dashboard', configDir: '/home/user/.config/miobridge', adapters });
   return { service, installed, removed, versions, dashboards };
 }
 
@@ -62,6 +62,16 @@ describe('CLI self maintenance', () => {
     ]);
   });
 
+  it('removes the complete runtime directory only with explicit purge', async () => {
+    const { service, removed } = harness();
+    await expect(service.uninstall({ purge: true })).resolves.toContain('managed dependencies removed');
+    expect(removed).toEqual([
+      '/home/user/.local/bin/miobridge',
+      '/home/user/.local/bin/.miobridge-cli-version',
+      '/home/user/.config/miobridge',
+    ]);
+  });
+
   it('extracts the executable from the release tarball', async () => {
     const root = await mkdtemp(join(tmpdir(), 'miobridge-self-tar-'));
     try {
@@ -74,13 +84,18 @@ describe('CLI self maintenance', () => {
       await writeFile(binary, '#!/bin/sh\necho 1.2.3\n');
       await chmod(binary, 0o755);
       execFileSync('tar', ['-czf', archive, '-C', root, 'miobridge', 'dashboard']);
-      const adapters = createNodeSelfMaintenanceAdapters();
-      const archiveData = await readFile(archive);
-      const extracted = await adapters.extractTarGzipEntry(archiveData, 'miobridge');
-      expect(new TextDecoder().decode(extracted)).toContain('echo 1.2.3');
-      const installedDashboard = join(root, 'installed-dashboard');
-      await adapters.installDashboard(installedDashboard, archiveData);
-      expect(await readFile(join(installedDashboard, 'artifact', 'index.html'), 'utf8')).toContain('current');
+      vi.stubGlobal('DecompressionStream', undefined);
+      try {
+        const adapters = createNodeSelfMaintenanceAdapters();
+        const archiveData = await readFile(archive);
+        const extracted = await adapters.extractTarGzipEntry(archiveData, 'miobridge');
+        expect(new TextDecoder().decode(extracted)).toContain('echo 1.2.3');
+        const installedDashboard = join(root, 'installed-dashboard');
+        await adapters.installDashboard(installedDashboard, archiveData);
+        expect(await readFile(join(installedDashboard, 'artifact', 'index.html'), 'utf8')).toContain('current');
+      } finally {
+        vi.unstubAllGlobals();
+      }
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/packages/cli/test/setup/setup.test.ts
+++ b/packages/cli/test/setup/setup.test.ts
@@ -1,16 +1,31 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createRuntimePaths } from '@miobridge/core';
 import { detectLinuxPlatform } from '../../src/platform/linux.js';
+import { downloadBytes } from '../../src/platform/download.js';
 import { DependencySetupService } from '../../src/setup/service.js';
 import { createNodeSetupAdapters } from '../../src/setup/nodeAdapters.js';
 import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { deflateRawSync, gzipSync } from 'node:zlib';
 import type { ArtifactCatalog, SetupAdapters } from '../../src/setup/types.js';
 
 const bytes = new Uint8Array([1, 2, 3]);
 const artifact = { version: 'v1.2.3', url: 'https://user:secret@example.test/download?token=private', sha256: 'trusted', archive: 'binary' as const, versionArgs: ['--version'] };
 const artifacts: ArtifactCatalog = { mihomo: { x64: artifact, arm64: artifact } };
+
+function zipEntry(name: string, contents: Uint8Array): Uint8Array {
+  const encodedName = Buffer.from(name);
+  const compressed = deflateRawSync(contents);
+  const header = Buffer.alloc(30);
+  header.writeUInt32LE(0x04034b50, 0);
+  header.writeUInt16LE(20, 4);
+  header.writeUInt16LE(8, 8);
+  header.writeUInt32LE(compressed.length, 18);
+  header.writeUInt32LE(contents.length, 22);
+  header.writeUInt16LE(encodedName.length, 26);
+  return new Uint8Array(Buffer.concat([header, encodedName, compressed]));
+}
 
 function harness(overrides: Partial<SetupAdapters> = {}, executable = new Set<string>()) {
   const installed: string[] = [];
@@ -27,6 +42,30 @@ function harness(overrides: Partial<SetupAdapters> = {}, executable = new Set<st
 describe('Linux platform detection', () => {
   it('maps supported architectures and distro', () => expect(detectLinuxPlatform({ platform: 'linux', architecture: 'aarch64', osRelease: 'ID=ubuntu\n' })).toEqual({ os: 'linux', architecture: 'arm64', distro: 'ubuntu' }));
   it.each([['darwin', 'x64', 'operating system'], ['linux', 'riscv64', 'architecture']])('rejects unsupported %s/%s', (platform, architecture, message) => expect(() => detectLinuxPlatform({ platform, architecture })).toThrow(message));
+});
+
+describe('release downloads', () => {
+  it('retries transient fetch failures before returning verified bytes', async () => {
+    const fetcher = vi.fn()
+      .mockRejectedValueOnce(new Error('connection reset'))
+      .mockResolvedValueOnce(new Response(bytes));
+    await expect(downloadBytes('https://example.test/artifact', {
+      attempts: 2,
+      retryDelayMs: 0,
+      fetcher,
+    })).resolves.toEqual(bytes);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports the final error after exhausting retries', async () => {
+    const fetcher = vi.fn(async () => { throw new Error('network unavailable'); });
+    await expect(downloadBytes('https://example.test/artifact', {
+      attempts: 3,
+      retryDelayMs: 0,
+      fetcher,
+    })).rejects.toThrow('network unavailable');
+    expect(fetcher).toHaveBeenCalledTimes(3);
+  });
 });
 
 describe('DependencySetupService', () => {
@@ -68,6 +107,30 @@ describe('DependencySetupService', () => {
 });
 
 describe('atomic managed installation', () => {
+  it('extracts gzip dependencies without relying on browser stream globals', async () => {
+    const contents = new TextEncoder().encode('mihomo executable fixture');
+    vi.stubGlobal('DecompressionStream', undefined);
+    try {
+      const result = await createNodeSetupAdapters().extract(new Uint8Array(gzipSync(contents)), {
+        ...artifact,
+        archive: 'gzip',
+      });
+      expect(result).toEqual(contents);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('extracts deflated zip dependencies with node-compatible zlib', async () => {
+    const contents = new TextEncoder().encode('zip executable fixture');
+    const result = await createNodeSetupAdapters().extract(zipEntry('tool.exe', contents), {
+      ...artifact,
+      archive: 'zip',
+      entry: 'tool.exe',
+    });
+    expect(result).toEqual(contents);
+  });
+
   it('preserves the previous executable when validation fails', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'miobridge-setup-test-'));
     const target = join(directory, 'mihomo');

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -139,7 +139,11 @@ echo "MioBridge CLI $VERSION installed at $binary"
 echo "Dashboard provider installed at $dashboard"
 if [ "$RUN_SETUP" -eq 1 ]; then
   echo "Installing required runtime dependencies through the CLI..."
-  "$binary" setup --yes
+  if ! "$binary" setup --yes; then
+    echo "MioBridge CLI $VERSION is installed, but runtime dependency setup failed." >&2
+    echo "Retry with: $binary setup --yes" >&2
+    exit 1
+  fi
 fi
 
 case ":${PATH:-}:" in


### PR DESCRIPTION
## What changed

- replace browser-only `DecompressionStream` usage with `node:zlib` for managed dependency and self-upgrade archives
- retry transient release download and timeout failures with bounded attempts
- add `miobridge uninstall --purge` while preserving the safe default uninstall behavior
- clarify bootstrap failures that occur after the CLI itself has already been installed
- add gzip, zip, release-installer, purge-uninstall, and no-browser-global regression coverage

## Root cause

The compiled Bun 1.0.0 CLI did not provide the `DecompressionStream` global used by the setup and self-maintenance adapters. The bootstrap installer therefore downloaded the release successfully, installed the CLI, and then failed while extracting the pinned mihomo dependency.

## Impact

The one-line installer can now complete the real pinned mihomo setup. Operators can retain runtime data with `uninstall` or explicitly remove all MioBridge-managed runtime state with `uninstall --purge`.

## Validation

- `bun run cli:typecheck`
- `bun run cli:test` — 13 files, 111 tests passed
- packaged version `1.0.0` for Linux x64 and arm64; verified all archives and SHA256 entries
- installed the packaged x64 release into an isolated HOME, ran mihomo v1.19.12, then ran `uninstall --purge`
- verified zero files remained in the isolated HOME after uninstall
