### PR TITLE
fix: 切换指标窗口时丢弃过期响应，避免图表与高亮不一致

### DIFF
--- a/packages/frontend/src/components/Dashboard.tsx
+++ b/packages/frontend/src/components/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { Icon } from '@iconify/react'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { apiService, type ApiStatus } from '@/lib/api'
 import type { ClusterStatus, MetricsSnapshot, MetricsSummary } from '@/lib/types'
@@ -52,12 +52,27 @@ export default function Dashboard({ initialCluster = null, initialStatus = null,
   const [metricRange, setMetricRange] = useState<'24h' | '7d' | '30d'>('24h')
   const [metrics, setMetrics] = useState<{ snapshot: MetricsSnapshot; history: MetricsSnapshot[]; summary: MetricsSummary } | null>(null)
 
+  // 每次刷新领一个序号，只有最新那次的响应可以写入状态。切换指标窗口会立刻发起
+  // 新请求，而先发的请求完全可能后到；不做丢弃的话它会把新窗口的数据覆盖回旧数据，
+  // 出现「按钮高亮 30d、图表画的却是 24h」这种界面自相矛盾的状态。
+  const requestSeq = useRef(0)
+
   const refresh = useCallback(async () => {
-    const [nextStatus, nextCluster, nextMetrics] = await Promise.all([
-      apiService.getStatus(),
-      apiService.getClusterStatus(),
-      apiService.getMetrics(metricRange),
-    ])
+    const seq = ++requestSeq.current
+    let responses
+    try {
+      responses = await Promise.all([
+        apiService.getStatus(),
+        apiService.getClusterStatus(),
+        apiService.getMetrics(metricRange),
+      ])
+    } catch (error) {
+      // 过期请求的失败同样要丢弃：新窗口已经加载成功时，不该再弹一条旧窗口的错误。
+      if (seq !== requestSeq.current) return
+      throw error
+    }
+    if (seq !== requestSeq.current) return
+    const [nextStatus, nextCluster, nextMetrics] = responses
     setStatus(nextStatus)
     if (nextCluster.success) setCluster(nextCluster.data as ClusterStatus)
     if (nextMetrics.success && nextMetrics.data) setMetrics(nextMetrics.data)

--- a/packages/frontend/src/components/__tests__/dashboard-metrics-race.test.tsx
+++ b/packages/frontend/src/components/__tests__/dashboard-metrics-race.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import type { MetricsSnapshot, MetricsSummary } from '@/lib/types'
+
+const mocks = vi.hoisted(() => ({ getMetrics: vi.fn(), getStatus: vi.fn(), getClusterStatus: vi.fn() }))
+
+vi.mock('@/lib/api', () => ({
+  apiService: {
+    getStatus: mocks.getStatus,
+    getClusterStatus: mocks.getClusterStatus,
+    getMetrics: mocks.getMetrics,
+  },
+}))
+
+function summary(): MetricsSummary {
+  return {
+    deploymentSuccessRate: null, deploymentCompleted: 0, deploymentAverageDurationMs: null,
+    deploymentStepAverageDurationMs: {}, agentOnlineRate: null, sourceSuccessRate: null,
+    subscriptionSuccessRate: null, subscriptionJobs: 0, artifactAverageAgeSeconds: null,
+    artifactMaximumAgeSeconds: null,
+  }
+}
+
+/** 用快照条数区分是哪一个窗口的响应：界面上会渲染成「N 个快照样本」。 */
+function metricsWith(snapshots: number) {
+  return {
+    success: true,
+    data: {
+      range: '',
+      snapshot: {} as MetricsSnapshot,
+      history: Array.from({ length: snapshots }, () => ({}) as MetricsSnapshot),
+      summary: summary(),
+    },
+  }
+}
+
+/** 一个可以由测试决定何时兑现的 promise，用来精确编排响应到达顺序。 */
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(res => { resolve = res })
+  return { promise, resolve }
+}
+
+describe('Dashboard 指标窗口竞态', () => {
+  it('先发的旧窗口响应后到时不得覆盖新窗口的数据', async () => {
+    const slow24h = deferred<unknown>()
+    const fast30d = deferred<unknown>()
+
+    mocks.getStatus.mockResolvedValue({})
+    mocks.getClusterStatus.mockResolvedValue({ success: true, data: null })
+    mocks.getMetrics.mockImplementation((range: string) =>
+      range === '24h' ? slow24h.promise : fast30d.promise)
+
+    const Dashboard = (await import('@/components/Dashboard')).default
+    render(<MemoryRouter><Dashboard /></MemoryRouter>)
+
+    // 挂载时按默认的 24h 发起请求，此时切到 30d，两个请求同时在途。
+    await waitFor(() => expect(mocks.getMetrics).toHaveBeenCalledWith('24h'))
+    fireEvent.click(screen.getByRole('button', { name: '30d' }))
+    await waitFor(() => expect(mocks.getMetrics).toHaveBeenCalledWith('30d'))
+
+    // 后发的 30d 先返回，再让先发的 24h 迟到。
+    fast30d.resolve(metricsWith(30))
+    await waitFor(() => expect(screen.getByText('30 个快照样本')).toBeDefined())
+
+    slow24h.resolve(metricsWith(24))
+    await new Promise(res => setTimeout(res, 0))
+
+    // 按钮高亮的是 30d，图表就必须还是 30d 的数据。
+    expect(screen.getByText('30 个快照样本')).toBeDefined()
+    expect(screen.queryByText('24 个快照样本')).toBeNull()
+  })
+})


### PR DESCRIPTION
## 问题

总览页的 `refresh` 没有任何取消或丢弃机制。快速切换 `24h → 7d → 30d` 时，先发的请求完全可能后到，把新窗口的数据覆盖回旧数据。

结果是界面停在**按钮高亮 30d、图表画的却是 24h** 这种自相矛盾的状态，而且不会自愈 —— 用户必须再点一次才能恢复，但页面本身没有任何迹象提示数据是错的。

这是既有缺陷，与 #12 无关，因此单独提出。

## 修复

每次刷新领一个序号，只有最新那次的响应可以写入状态。过期请求的**失败**也一并丢弃 —— 否则新窗口已经加载成功时，还会弹出一条属于旧窗口的错误提示。

## 验证

新增 `dashboard-metrics-race.test.tsx`，用可控兑现顺序精确复现竞态（让后发的 30d 先返回、先发的 24h 迟到）。已确认撤掉修复即失败。

全量：frontend 45、core 35、CLI 136、typecheck 与 lint 均通过；`shell-overview.spec.ts` 19/19 通过（含「24h/7d/30d 指标窗口均命中真实路由」）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fwMtFZAv8AHr8i841ecCF