### PR TITLE
fix: 刷新失败时给出提示，不再静默吞掉错误（补 #14 丢失的合并）

### DIFF
--- a/packages/frontend/src/components/Dashboard.tsx
+++ b/packages/frontend/src/components/Dashboard.tsx
@@ -57,7 +57,8 @@ export default function Dashboard({ initialCluster = null, initialStatus = null,
   // 出现「按钮高亮 30d、图表画的却是 24h」这种界面自相矛盾的状态。
   const requestSeq = useRef(0)
 
-  const refresh = useCallback(async () => {
+  /** 返回 false 表示这次响应已被更新的请求取代，没有写入任何状态。 */
+  const refresh = useCallback(async (): Promise<boolean> => {
     const seq = ++requestSeq.current
     let responses
     try {
@@ -68,23 +69,30 @@ export default function Dashboard({ initialCluster = null, initialStatus = null,
       ])
     } catch (error) {
       // 过期请求的失败同样要丢弃：新窗口已经加载成功时，不该再弹一条旧窗口的错误。
-      if (seq !== requestSeq.current) return
+      if (seq !== requestSeq.current) return false
       throw error
     }
-    if (seq !== requestSeq.current) return
+    if (seq !== requestSeq.current) return false
     const [nextStatus, nextCluster, nextMetrics] = responses
     setStatus(nextStatus)
     if (nextCluster.success) setCluster(nextCluster.data as ClusterStatus)
     if (nextMetrics.success && nextMetrics.data) setMetrics(nextMetrics.data)
+    return true
   }, [metricRange])
+
+  // 首次加载和刷新按钮共用同一条失败路径。把 refresh 直接交给 onClick 的话，
+  // 失败只会变成一条未捕获的 promise rejection，用户点了按钮什么都看不到。
+  // 只有真正写入了状态才清除旧错误：被取代的过期响应不足以证明后端已经恢复。
+  const runRefresh = useCallback(() => {
+    refresh()
+      .then(applied => { if (applied) setError(null) })
+      .catch((err: unknown) => setError(err instanceof Error ? err.message : '加载失败'))
+  }, [refresh])
 
   useEffect(() => {
     if (initialStatus !== null || initialCluster !== null) return
-    refresh().catch((err: unknown) => {
-      const message = err instanceof Error ? err.message : '加载失败'
-      setError(message)
-    })
-  }, [initialCluster, initialStatus, refresh])
+    runRefresh()
+  }, [initialCluster, initialStatus, runRefresh])
 
   const missingFiles = status ? FILES.filter(file => !status[file.key]) : FILES
   const remoteNodes = cluster?.nodes.filter(node => node.nodeId !== 'local') || []
@@ -111,7 +119,7 @@ export default function Dashboard({ initialCluster = null, initialStatus = null,
       maxWidth="narrow"
       actions={(
         <>
-          <Button variant="outline" onClick={refresh}><Icon icon="ph:arrow-clockwise-light" />刷新摘要</Button>
+          <Button variant="outline" onClick={runRefresh}><Icon icon="ph:arrow-clockwise-light" />刷新摘要</Button>
           <Button asChild variant="outline">
             <Link to="/subscription">
               前往订阅生成

--- a/packages/frontend/src/components/__tests__/dashboard-refresh-error.test.tsx
+++ b/packages/frontend/src/components/__tests__/dashboard-refresh-error.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+const mocks = vi.hoisted(() => ({ getMetrics: vi.fn(), getStatus: vi.fn(), getClusterStatus: vi.fn() }))
+
+vi.mock('@/lib/api', () => ({
+  apiService: {
+    getStatus: mocks.getStatus,
+    getClusterStatus: mocks.getClusterStatus,
+    getMetrics: mocks.getMetrics,
+  },
+}))
+
+const initialStatus = {
+  rawExists: true, subscriptionExists: true, clashExists: true, mihomoAvailable: true,
+  nodesCount: 3, uptime: 120, version: '1.0.0', mihomoVersion: '1.19.0',
+}
+
+function renderDashboard(Dashboard: React.ComponentType<{ initialStatus?: typeof initialStatus }>) {
+  // 传入初始数据，挂载时不会自动拉取，这样点击才是唯一的请求来源。
+  return render(<MemoryRouter><Dashboard initialStatus={initialStatus} /></MemoryRouter>)
+}
+
+describe('Dashboard 刷新失败反馈', () => {
+  beforeEach(() => {
+    mocks.getClusterStatus.mockResolvedValue({ success: true, data: null })
+    mocks.getMetrics.mockResolvedValue({ success: true, data: null })
+  })
+
+  it('点击刷新失败时把错误告诉用户，而不是静默吞掉', async () => {
+    mocks.getStatus.mockRejectedValue(new Error('后端连接被拒绝'))
+    const Dashboard = (await import('@/components/Dashboard')).default
+    renderDashboard(Dashboard)
+
+    fireEvent.click(screen.getByRole('button', { name: /刷新摘要/ }))
+
+    await waitFor(() => expect(screen.getByText('状态异常')).toBeDefined())
+    expect(screen.getByText('后端连接被拒绝')).toBeDefined()
+  })
+
+  it('重新刷新成功后清掉上一次的错误提示', async () => {
+    mocks.getStatus.mockRejectedValueOnce(new Error('后端连接被拒绝')).mockResolvedValue(initialStatus)
+    const Dashboard = (await import('@/components/Dashboard')).default
+    renderDashboard(Dashboard)
+
+    fireEvent.click(screen.getByRole('button', { name: /刷新摘要/ }))
+    await waitFor(() => expect(screen.getByText('状态异常')).toBeDefined())
+
+    fireEvent.click(screen.getByRole('button', { name: /刷新摘要/ }))
+    await waitFor(() => expect(screen.queryByText('状态异常')).toBeNull())
+  })
+})


### PR DESCRIPTION
> **补合并**：#14 已显示为 MERGED，但它的 base 是 `fix/dashboard-metrics-race`——该分支在 #13 squash 合并进 main 后就成了死分支，所以 `d4404dc` 从未到达 main。本 PR 把同一个提交 (`534dd97`) cherry-pick 到当前 main，内容与 #14 完全一致，无冲突。

## 问题

刷新按钮是 `onClick={refresh}`，把 async 函数直接交给事件处理器：

- 请求失败没有任何人捕获，只留下一条未处理的 promise rejection；
- 页面**毫无变化**——用户只会觉得「点了没反应」，无从判断是后端挂了还是自己没点到。

同一条路径上还有第二个问题：错误提示一旦出现就再也不会消失，即使后端早已恢复、数据也刷新成功，红色告警仍然挂在页面顶部。

## 修复

把首次加载已有的失败处理提取成 `runRefresh`，按钮和挂载两处共用；成功后清除旧错误。

清除只在**真正写入了状态**时发生——被更新请求取代的过期响应不足以证明后端已恢复（承接 #13 的序号丢弃机制），为此 `refresh` 改为返回是否已应用。

## 验证

在当前 main + 本提交上跑的完整验证：

- E2E（Playwright）**145/145**
- frontend 53、CLI 136、core 42
- typecheck、lint 均为 0

两条新用例此前已确认先以正确方式失败：修复前第一条的输出里能直接看到那条逃逸的 `Error: 后端连接被拒绝`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fwMtFZAv8AHr8i841ecCF