### PR TITLE
feat: upgrade 全程可见进度，运行中的 dashboard 服务自动重启

### DIFF
--- a/packages/cli/src/dashboard/systemd.ts
+++ b/packages/cli/src/dashboard/systemd.ts
@@ -142,6 +142,22 @@ export class DashboardSystemdService {
     return result;
   }
 
+  /**
+   * 原地重启已在运行的服务。刻意不走 stop()+start()：start() 会用当前进程的
+   * 路径重写单元文件，如果调用方（比如 upgrade）是从别的位置运行的，会把
+   * ExecStart 劫持过去，服务直接进入 203/EXEC 崩溃循环。升级场景里二进制是
+   * 在原路径上原子替换的，单元定义一个字都不需要动。
+   */
+  async restart(): Promise<void> {
+    const result = await this.adapters.run('systemctl', ['--user', 'restart', DASHBOARD_UNIT_NAME]);
+    if (result.exitCode !== 0) throw new Error(`Could not restart dashboard: ${output(result) || 'systemctl failed'}`);
+    const host = this.options.host ?? '0.0.0.0';
+    const port = this.options.port ?? 3000;
+    if (!(await this.adapters.waitForReady(host, port))) {
+      throw new Error(`Dashboard service did not become ready at http://${host}:${port}/health. Inspect logs with: ${this.journalCommand()}`);
+    }
+  }
+
   async stop(): Promise<DashboardDaemonStatus> {
     const current = await this.status();
     if (current.state === 'unsupported') throw new Error(current.message);

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -23,6 +23,21 @@ const maintenance = new SelfMaintenanceService({
   dashboardPath: `${composition.paths.distDir}/dashboard`,
   configDir: composition.paths.baseDir,
   adapters: createNodeSelfMaintenanceAdapters(),
+  progress: message => output.stdout(message),
+  serviceControl: {
+    async detect() {
+      if ((await dashboardDaemon.status()).state === 'running') return 'systemd';
+      // systemd 没接管但端口上有活的 dashboard，多半是前台进程还在跑旧版本。
+      const port = Number(process.env.MIOBRIDGE_DASHBOARD_PORT) || dashboardConfig?.port || 3000;
+      try {
+        const response = await fetch(`http://127.0.0.1:${port}/health`, { signal: AbortSignal.timeout(2_000) });
+        return response.ok ? 'external' : 'none';
+      } catch {
+        return 'none';
+      }
+    },
+    restart: () => dashboardDaemon.restart(),
+  },
   ...(process.env.MIOBRIDGE_REPOSITORY ? { repository: process.env.MIOBRIDGE_REPOSITORY } : {}),
   ...(process.env.MIOBRIDGE_VERSION ? { targetVersion: process.env.MIOBRIDGE_VERSION } : {}),
   ...(process.env.MIOBRIDGE_RELEASE_BASE_URL ? { releaseBaseUrl: process.env.MIOBRIDGE_RELEASE_BASE_URL } : {}),

--- a/packages/cli/src/platform/download.ts
+++ b/packages/cli/src/platform/download.ts
@@ -1,8 +1,15 @@
 export interface DownloadOptions {
   readonly attempts?: number;
+  /**
+   * 空闲超时：连续这么多毫秒没有收到任何数据才中止本次尝试。
+   * 之前是整次下载的总时长上限，结果慢而健康的链路（比如跨境拉 GitHub
+   * Release）永远在 120s 处被掐断重来，一次都完不成；停摆和缓慢必须区分。
+   */
   readonly timeoutMs?: number;
   readonly retryDelayMs?: number;
   readonly fetcher?: (input: string, init: RequestInit) => Promise<Response>;
+  readonly onProgress?: (receivedBytes: number, totalBytes?: number) => void;
+  readonly onRetry?: (attempt: number, error: unknown) => void;
 }
 
 const delay = (milliseconds: number) => new Promise(resolve => setTimeout(resolve, milliseconds));
@@ -15,13 +22,58 @@ export async function downloadBytes(url: string, options: DownloadOptions = {}):
   let lastError: unknown;
 
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    // abort 负责撕掉真实网络流；idle promise 负责叫醒 race——测试或代理注入的
+    // Response 可能不理会 signal，只靠 abort 的话 read() 会永远悬着。
+    const controller = new AbortController();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let expire: (() => void) | undefined;
+    const idle = new Promise<never>((_, reject) => {
+      expire = () => reject(new Error(`Download stalled: no data received for ${timeoutMs}ms`));
+    });
+    idle.catch(() => undefined); // 正常完成时无人等待这个 promise，不能变成未处理拒绝。
+    const arm = () => {
+      clearTimeout(timer);
+      timer = setTimeout(() => { controller.abort(); expire?.(); }, timeoutMs);
+    };
     try {
-      const response = await fetcher(url, { redirect: 'follow', signal: AbortSignal.timeout(timeoutMs) });
+      arm();
+      const response = await Promise.race([fetcher(url, { redirect: 'follow', signal: controller.signal }), idle]);
       if (!response.ok) throw new Error(`Download failed with HTTP ${response.status}`);
-      return new Uint8Array(await response.arrayBuffer());
+      if (!response.body) {
+        const bytes = new Uint8Array(await Promise.race([response.arrayBuffer(), idle]));
+        options.onProgress?.(bytes.length, bytes.length);
+        return bytes;
+      }
+      const lengthHeader = response.headers.get('content-length');
+      const total = lengthHeader && /^\d+$/.test(lengthHeader) ? Number(lengthHeader) : undefined;
+      const reader = response.body.getReader();
+      try {
+        const chunks: Uint8Array[] = [];
+        let received = 0;
+        for (;;) {
+          const { done, value } = await Promise.race([reader.read(), idle]);
+          if (done) break;
+          arm();
+          received += value.byteLength;
+          chunks.push(value);
+          options.onProgress?.(received, total);
+        }
+        const data = new Uint8Array(received);
+        let offset = 0;
+        for (const chunk of chunks) { data.set(chunk, offset); offset += chunk.byteLength; }
+        return data;
+      } catch (error) {
+        await reader.cancel().catch(() => undefined);
+        throw error;
+      }
     } catch (error) {
       lastError = error;
-      if (attempt < attempts) await delay(retryDelayMs * attempt);
+      if (attempt < attempts) {
+        options.onRetry?.(attempt, error);
+        await delay(retryDelayMs * attempt);
+      }
+    } finally {
+      clearTimeout(timer);
     }
   }
 

--- a/packages/cli/src/self/service.ts
+++ b/packages/cli/src/self/service.ts
@@ -1,10 +1,18 @@
 import { dirname, join } from 'node:path';
 import type { LinuxPlatform } from '../platform/linux.js';
 
+export interface DownloadProgressHooks {
+  onProgress?(receivedBytes: number, totalBytes?: number): void;
+  onRetry?(attempt: number, error: unknown): void;
+}
+
+/** 升级完成后可能仍在运行旧版本的 dashboard 形态。 */
+export type RunningDashboard = 'systemd' | 'external' | 'none';
+
 export interface SelfMaintenanceAdapters {
   platform(): Promise<LinuxPlatform>;
   latestVersion(repository: string): Promise<string>;
-  download(url: string): Promise<Uint8Array>;
+  download(url: string, hooks?: DownloadProgressHooks): Promise<Uint8Array>;
   sha256(data: Uint8Array): Promise<string>;
   extractTarGzipEntry(data: Uint8Array, entry: string): Promise<Uint8Array>;
   installAtomic(path: string, data: Uint8Array, validate: (temporaryPath: string) => Promise<void>): Promise<void>;
@@ -23,6 +31,16 @@ export interface SelfMaintenanceOptions {
   readonly releaseBaseUrl?: string;
   readonly dashboardPath: string;
   readonly configDir: string;
+  /** 每个阶段的人类可读进度；不提供则静默（保持旧行为）。 */
+  readonly progress?: (message: string) => void;
+  /**
+   * 升级完成后接管仍在运行旧版本的 dashboard。systemd 托管的直接重启；
+   * 前台进程挂在用户自己的终端上，杀掉也无法原地拉起，只能明确警告。
+   */
+  readonly serviceControl?: {
+    detect(): Promise<RunningDashboard>;
+    restart(): Promise<void>;
+  };
 }
 
 function normalizeVersion(version: string): string {
@@ -49,7 +67,9 @@ export class SelfMaintenanceService {
   }
 
   async upgrade(): Promise<string> {
+    const progress = this.options.progress ?? (() => undefined);
     const platform = await this.options.adapters.platform();
+    if (!this.options.targetVersion) progress(`Resolving latest release of ${this.repository}...`);
     const version = normalizeVersion(
       this.options.targetVersion ?? await this.options.adapters.latestVersion(this.repository),
     );
@@ -57,14 +77,38 @@ export class SelfMaintenanceService {
 
     const archive = `miobridge-${version}-linux-${platform.architecture}.tar.gz`;
     const baseUrl = this.options.releaseBaseUrl ?? `https://github.com/${this.repository}/releases/download/v${version}`;
+    progress(`Downloading ${archive} from ${baseUrl}...`);
+    const megabytes = (bytes: number) => (bytes / 1048576).toFixed(1);
+    let reportedPercent = -25;
+    let reportedBytes = 0;
     const [archiveData, checksums] = await Promise.all([
-      this.options.adapters.download(`${baseUrl}/${archive}`),
+      this.options.adapters.download(`${baseUrl}/${archive}`, {
+        onProgress: (received, total) => {
+          // 有总量按 25% 一档报，没有就每 8 MiB 报一次；再密就是刷屏了。
+          if (total) {
+            const percent = Math.floor((received / total) * 100);
+            if (percent >= reportedPercent + 25 || (percent === 100 && reportedPercent < 100)) {
+              reportedPercent = percent;
+              progress(`Downloading ${archive}: ${percent}% (${megabytes(received)}/${megabytes(total)} MB)`);
+            }
+          } else if (received >= reportedBytes + 8 * 1048576) {
+            reportedBytes = received;
+            progress(`Downloading ${archive}: ${megabytes(received)} MB received`);
+          }
+        },
+        onRetry: (attempt, error) => {
+          const reason = error instanceof Error ? error.message : String(error);
+          progress(`Download interrupted (${reason}); starting retry ${attempt + 1}...`);
+        },
+      }),
       this.options.adapters.download(`${baseUrl}/SHA256SUMS`),
     ]);
+    progress('Verifying SHA-256 checksum...');
     const expected = expectedDigest(checksums, archive);
     const actual = (await this.options.adapters.sha256(archiveData)).toLowerCase();
     if (actual !== expected) throw new Error(`Checksum verification failed for ${archive}`);
 
+    progress(`Installing MioBridge ${version} (CLI + dashboard)...`);
     const binary = await this.options.adapters.extractTarGzipEntry(archiveData, 'miobridge');
     await this.options.adapters.installAtomic(this.options.executablePath, binary, async temporaryPath => {
       const reported = normalizeVersion(await this.options.adapters.probeVersion(temporaryPath));
@@ -72,7 +116,28 @@ export class SelfMaintenanceService {
     });
     await this.options.adapters.installDashboard(this.options.dashboardPath, archiveData);
     await this.options.adapters.writeVersion(join(dirname(this.options.executablePath), '.miobridge-cli-version'), version);
-    return `MioBridge and dashboard upgraded from ${this.options.currentVersion} to ${version}.`;
+    const upgraded = `MioBridge and dashboard upgraded from ${this.options.currentVersion} to ${version}.`;
+    return `${upgraded}${await this.handOverRunningDashboard(version, progress)}`;
+  }
+
+  /** 磁盘上的新版本就位后，处理还在跑旧版本的服务；返回追加到结果末尾的说明。 */
+  private async handOverRunningDashboard(version: string, progress: (message: string) => void): Promise<string> {
+    const control = this.options.serviceControl;
+    if (!control) return '';
+    let running: RunningDashboard = 'none';
+    try { running = await control.detect(); } catch { return ''; } // 探测失败不能拖垮已完成的升级。
+    if (running === 'external') {
+      return ` A running dashboard not managed by systemd still serves the old version; restart it manually to apply ${version}.`;
+    }
+    if (running !== 'systemd') return '';
+    progress('Restarting dashboard service...');
+    try {
+      await control.restart();
+      return ' Dashboard service restarted.';
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      return ` Dashboard restart failed: ${reason} Run "miobridge dashboard start" manually.`;
+    }
   }
 
   async uninstall(options: { readonly purge?: boolean } = {}): Promise<string> {

--- a/packages/cli/test/dashboard/systemd.test.ts
+++ b/packages/cli/test/dashboard/systemd.test.ts
@@ -138,6 +138,30 @@ describe('dashboard systemd user lifecycle', () => {
     expect(restarting.calls.some(([, args]) => args.includes('disable') && args.includes('--now'))).toBe(true);
   });
 
+  it('restarts in place without rewriting the unit definition', async () => {
+    const { service, calls, files } = await fixture({}, { active: true, enabled: true });
+    await service.restart();
+    expect(calls.some(([, args]) => args.includes('restart'))).toBe(true);
+    // 不得重写单元文件：如果 upgrade 是从别的路径运行的，重写会把
+    // ExecStart 劫持到那个路径，服务立刻进入 203/EXEC 崩溃循环。
+    expect(files.size).toBe(0);
+  });
+
+  it('surfaces a restart that never becomes ready', async () => {
+    const { service } = await fixture({ waitForReady: async () => false }, { active: true, enabled: true });
+    await expect(service.restart()).rejects.toThrow(/journalctl/);
+  });
+
+  it('surfaces a restart the service manager rejects', async () => {
+    const { service } = await fixture({
+      async run(command, args) {
+        if (args.includes('restart')) return { exitCode: 1, stdout: '', stderr: 'unit masked' };
+        return { exitCode: 0, stdout: 'active\n', stderr: '' };
+      },
+    }, { active: true, enabled: true });
+    await expect(service.restart()).rejects.toThrow(/unit masked/);
+  });
+
   it('removes the managed unit and reloads systemd during CLI uninstall', async () => {
     const installed = await fixture({}, { active: true, enabled: true });
     await installed.service.uninstall();

--- a/packages/cli/test/download.test.ts
+++ b/packages/cli/test/download.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest'
+import { downloadBytes } from '../src/platform/download.js'
+
+function chunkedResponse(chunks: Uint8Array[], headers: Record<string, string> = {}): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk)
+      controller.close()
+    },
+  })
+  return new Response(stream, { status: 200, headers })
+}
+
+describe('downloadBytes', () => {
+  it('streams the body and reports progress with the declared total', async () => {
+    const seen: Array<[number, number | undefined]> = []
+    const data = await downloadBytes('https://example.test/a', {
+      fetcher: async () => chunkedResponse(
+        [new Uint8Array([1, 2, 3]), new Uint8Array([4, 5])],
+        { 'content-length': '5' },
+      ),
+      onProgress: (received, total) => seen.push([received, total]),
+    })
+    expect([...data]).toEqual([1, 2, 3, 4, 5])
+    expect(seen).toEqual([[3, 5], [5, 5]])
+  })
+
+  it('reports progress without a total when content-length is missing', async () => {
+    const seen: Array<[number, number | undefined]> = []
+    await downloadBytes('https://example.test/a', {
+      fetcher: async () => chunkedResponse([new Uint8Array([9])]),
+      onProgress: (received, total) => seen.push([received, total]),
+    })
+    expect(seen).toEqual([[1, undefined]])
+  })
+
+  it('notifies before each retry and eventually succeeds', async () => {
+    const retries: number[] = []
+    let calls = 0
+    const data = await downloadBytes('https://example.test/a', {
+      retryDelayMs: 1,
+      fetcher: async () => {
+        calls += 1
+        if (calls < 3) throw new Error('socket hang up')
+        return chunkedResponse([new Uint8Array([7])])
+      },
+      onRetry: attempt => retries.push(attempt),
+    })
+    expect([...data]).toEqual([7])
+    expect(retries).toEqual([1, 2])
+  })
+
+  it('aborts a stalled body but tolerates a slow-yet-moving download', async () => {
+    vi.useFakeTimers()
+    try {
+      // 龟速但一直有数据：每 40ms 一块，共 5 块，空闲超时 100ms —— 必须成功。
+      // 这是修复的核心语义：超时衡量的是「多久没有任何数据」，不是总时长。
+      let sent = 0
+      const slow = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (sent === 5) { controller.close(); return }
+          sent += 1
+          return new Promise(resolve => {
+            setTimeout(() => { controller.enqueue(new Uint8Array([sent])); resolve() }, 40)
+          })
+        },
+      })
+      const done = downloadBytes('https://example.test/slow', {
+        attempts: 1,
+        timeoutMs: 100,
+        fetcher: async () => new Response(slow, { status: 200 }),
+      })
+      await vi.advanceTimersByTimeAsync(400)
+      expect([...await done]).toEqual([1, 2, 3, 4, 5])
+
+      // 完全停摆的流：第一块之后再无数据 —— 必须在空闲超时后报错，而不是永远挂着。
+      const stalled = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (sent === 5) { sent += 1; controller.enqueue(new Uint8Array([0])); return }
+          return new Promise(() => { /* 永不推进 */ })
+        },
+      })
+      const failing = downloadBytes('https://example.test/stalled', {
+        attempts: 1,
+        timeoutMs: 100,
+        fetcher: async () => new Response(stalled, { status: 200 }),
+      })
+      const outcome = failing.then(() => 'resolved', () => 'rejected')
+      await vi.advanceTimersByTimeAsync(400)
+      expect(await outcome).toBe('rejected')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/packages/cli/test/self-maintenance.test.ts
+++ b/packages/cli/test/self-maintenance.test.ts
@@ -5,13 +5,16 @@ import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { describe, expect, it, vi } from 'vitest';
 import { createNodeSelfMaintenanceAdapters } from '../src/self/nodeAdapters.js';
-import { SelfMaintenanceService, type SelfMaintenanceAdapters } from '../src/self/service.js';
+import { SelfMaintenanceService, type SelfMaintenanceAdapters, type SelfMaintenanceOptions } from '../src/self/service.js';
 
 const archiveData = new TextEncoder().encode('archive');
 const binaryData = new TextEncoder().encode('binary');
 const digest = createHash('sha256').update(archiveData).digest('hex');
 
-function harness(overrides: Partial<SelfMaintenanceAdapters> = {}) {
+function harness(
+  overrides: Partial<SelfMaintenanceAdapters> = {},
+  options: Partial<Omit<SelfMaintenanceOptions, 'adapters'>> = {},
+) {
   const installed: string[] = [];
   const removed: string[] = [];
   const versions: string[] = [];
@@ -31,7 +34,7 @@ function harness(overrides: Partial<SelfMaintenanceAdapters> = {}) {
     remove: async path => { removed.push(path); },
     ...overrides,
   };
-  const service = new SelfMaintenanceService({ currentVersion: '1.0.0', executablePath: '/home/user/.local/bin/miobridge', dashboardPath: '/home/user/.config/miobridge/dist/dashboard', configDir: '/home/user/.config/miobridge', adapters });
+  const service = new SelfMaintenanceService({ currentVersion: '1.0.0', executablePath: '/home/user/.local/bin/miobridge', dashboardPath: '/home/user/.config/miobridge/dist/dashboard', configDir: '/home/user/.config/miobridge', adapters, ...options });
   return { service, installed, removed, versions, dashboards };
 }
 
@@ -70,6 +73,72 @@ describe('CLI self maintenance', () => {
       '/home/user/.local/bin/.miobridge-cli-version',
       '/home/user/.config/miobridge',
     ]);
+  });
+
+  it('reports each upgrade phase through the progress callback', async () => {
+    const events: string[] = [];
+    const { service } = harness({}, { progress: message => events.push(message) });
+    await service.upgrade();
+    const phases = ['Resolving', 'Downloading', 'Verifying', 'Installing'];
+    const indexes = phases.map(phase => events.findIndex(event => event.startsWith(phase)));
+    // 每个阶段都要出现，且按顺序出现——用户必须能区分「在下载」和「卡死了」。
+    expect(indexes.every(index => index >= 0)).toBe(true);
+    expect([...indexes]).toEqual([...indexes].sort((a, b) => a - b));
+  });
+
+  it('skips the resolve phase when a target version is pinned', async () => {
+    const events: string[] = [];
+    const latestVersion = vi.fn();
+    const { service } = harness({ latestVersion }, { targetVersion: '1.2.3', progress: message => events.push(message) });
+    await service.upgrade();
+    expect(latestVersion).not.toHaveBeenCalled();
+    expect(events.some(event => event.startsWith('Resolving'))).toBe(false);
+  });
+
+  it('relays download progress and retry notices', async () => {
+    const events: string[] = [];
+    const { service } = harness({
+      download: async (url, hooks) => {
+        if (url.endsWith('SHA256SUMS')) return new TextEncoder().encode(`${digest}  miobridge-1.2.3-linux-x64.tar.gz\n`);
+        hooks?.onRetry?.(1, new Error('socket hang up'));
+        hooks?.onProgress?.(archiveData.length, archiveData.length);
+        return archiveData;
+      },
+    }, { progress: message => events.push(message) });
+    await service.upgrade();
+    expect(events.some(event => event.includes('retry'))).toBe(true);
+    expect(events.some(event => /100%/.test(event))).toBe(true);
+  });
+
+  it('restarts a running systemd dashboard after the upgrade', async () => {
+    const restart = vi.fn(async () => undefined);
+    const { service } = harness({}, { serviceControl: { detect: async () => 'systemd', restart } });
+    await expect(service.upgrade()).resolves.toContain('Dashboard service restarted');
+    expect(restart).toHaveBeenCalledOnce();
+  });
+
+  it('leaves stopped dashboards alone', async () => {
+    const restart = vi.fn(async () => undefined);
+    const { service } = harness({}, { serviceControl: { detect: async () => 'none', restart } });
+    await expect(service.upgrade()).resolves.toBe('MioBridge and dashboard upgraded from 1.0.0 to 1.2.3.');
+    expect(restart).not.toHaveBeenCalled();
+  });
+
+  it('warns about an unmanaged running dashboard instead of touching it', async () => {
+    const restart = vi.fn(async () => undefined);
+    const { service } = harness({}, { serviceControl: { detect: async () => 'external', restart } });
+    // 前台进程挂在用户自己的终端上，杀掉它无法原地重启，只能明确警告。
+    await expect(service.upgrade()).resolves.toContain('restart it manually');
+    expect(restart).not.toHaveBeenCalled();
+  });
+
+  it('does not fail the finished upgrade when the restart fails', async () => {
+    const restart = vi.fn(async () => { throw new Error('systemctl busy'); });
+    const { service } = harness({}, { serviceControl: { detect: async () => 'systemd', restart } });
+    // 二进制和 dashboard 已经装好了，重启失败只能降级为带指引的警告。
+    const message = await service.upgrade();
+    expect(message).toContain('upgraded from 1.0.0 to 1.2.3');
+    expect(message).toContain('miobridge dashboard start');
   });
 
   it('extracts the executable from the release tarball', async () => {


### PR DESCRIPTION
## 背景

诊断「`miobridge upgrade` 卡住」的结论：代码各环节都有超时、不存在死锁，但 GitHub 链路间歇性停摆时 CLI **零输出**地静默等待（旧版最长 ~150s，带重试的新版最长 ~6 分钟），用户只能当它死了。另外升级完成后，运行中的 dashboard 服务继续跑旧版本，无提示也不重启。

## 改动

**1. 分阶段进度输出**
```
Resolving latest release of imal1/MioBridge...
Downloading miobridge-1.2.0-linux-x64.tar.gz from https://github.com/...
Downloading miobridge-1.2.0-linux-x64.tar.gz: 27% (9.6/35.4 MB)
...
Verifying SHA-256 checksum...
Installing MioBridge 1.2.0 (CLI + dashboard)...
Restarting dashboard service...
MioBridge and dashboard upgraded from 1.0.0 to 1.2.0. Dashboard service restarted.
```
有总量按 25% 步进，无 content-length 按 8 MiB 步进；重试时明确提示第几次。

**2. 下载超时从「总时长」改为「空闲时长」**
旧语义下 120s 内下载不完就被掐断从头再来 —— 慢而健康的跨境链路**一次都完不成**。现在只有连续 120s 无任何数据才中止；用 read-race 实现，不依赖 Response 是否理会 abort signal。

**3. 升级后自动接管运行中的服务**
- systemd 托管且在运行 → `systemctl --user restart` + 等待就绪
- 端口上有活的但非 systemd 托管（前台进程）→ 明确警告需手动重启（挂在用户终端上的进程无法替他原地拉起）
- 重启失败**不影响已完成的升级**，降级为带 `miobridge dashboard start` 指引的提示

**4. 新增 `DashboardSystemdService.restart()`，刻意不复用 stop()+start()**
`start()` 会用当前进程路径重写单元文件 —— 从别的路径运行 upgrade 会把 ExecStart 劫持过去，服务进入 203/EXEC 崩溃循环。这不是理论风险：第一版实现在真机冒烟中就踩到了，已用测试钉死「restart 不得写单元文件」。

## 验证

- TDD：12 条新用例全部先确认失败再实现（download 4、self-maintenance 7、systemd 3——含钉死单元文件不被重写）
- CLI 150/150、typecheck、lint 全过
- 真机端到端：编译自称 1.0.0 的二进制，从本地服务器升级到真实 1.2.0 产物 —— 阶段输出、进度、自动重启、单元文件未被改动、服务就绪后自报 1.2.0，全部命中

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fwMtFZAv8AHr8i841ecCF