### PR TITLE
Release 1.2.3 with rootless Agent deployment

### DIFF
--- a/.Codex/memory/bug-fixes.md
+++ b/.Codex/memory/bug-fixes.md
@@ -7,6 +7,9 @@ metadata:
 
 # Bug Fixes
 
+- 2026-07-19: Agent deployment no longer installs selected missing protocol
+  kernels. Agent and mihomo use user paths and user systemd without sudo; 233boy
+  wrappers run directly and elevate only after an explicit permission failure.
 - 2026-07-19: Local-node installation now bootstraps a verified Agent, reconciles
   its observed state, and keeps it in deployment/Agent/runtime/subscription flows.
   Multi-kernel collection uses each 233boy `url` command with per-config isolation;

--- a/.Codex/memory/ci-cd-pipeline.md
+++ b/.Codex/memory/ci-cd-pipeline.md
@@ -7,6 +7,12 @@ metadata:
 
 # CI/CD Pipeline
 
+## 2026-07-19 — Installer release assets
+
+Release packaging copies both `scripts/install.sh` and `scripts/install-agent.sh`
+to `dist/cli-release`, includes both in `SHA256SUMS`, and publishes both as
+GitHub Release assets.
+
 ## 2026-07-02 — Production deploys to Vercel
 
 Production deploys now use Vercel Git Integration, not GitHub Actions deploy

--- a/.Codex/memory/deployment-flow.md
+++ b/.Codex/memory/deployment-flow.md
@@ -13,26 +13,31 @@ metadata:
   run Vercel CLI.
 - Self-hosted Linux starts with the checksum-verifying `scripts/install.sh` and
   installs the CLI plus dashboard provider. Unless `--no-local-node` is selected,
-  it also creates the all-kernel local profile and bootstraps its
-  checksum-covered Agent; thereafter it uses only `miobridge` lifecycle commands.
+  it also creates the local profile and bootstraps its checksum-covered user
+  Agent; thereafter it uses only `miobridge` lifecycle commands.
 - The CLI is the management layer; `mihomo` and the optional `sing-box` runtime
   remain separately discovered or checksum-verified managed binaries.
 - Child Agent deployment selects a checksum-covered x64/arm64 binary from the
   matching MioBridge Release; child servers do not install Bun or compile source.
 - Child nodes may bootstrap or repair only the Agent with the release
-  `install-agent.sh`; it validates `agent.yaml`, installs an explicit `--config`
-  systemd unit, health-checks locally, and rolls binary/config/unit back together.
-- Child deployment detects every supported kernel, lets operators choose the
-  monitored set, installs selected missing kernels, then deploys one Agent config.
+  `install-agent.sh`; it validates `agent.yaml`, installs under the current user's
+  home with a user systemd unit, health-checks locally, and rolls
+  binary/config/unit back together without sudo.
+- Child deployment detects every supported kernel and monitors only the selected,
+  installed, readable set. It never installs a protocol kernel during Agent
+  deployment; kernel installation is a separate explicit operation.
 - New nodes persist as empty-kernel drafts; a successful deployment commits the
   selected kernels. Deployment IDs prevent stale jobs from overwriting newer
   node state or progress.
-- Remote Agent config and systemd unit replacement use checked same-directory
-  temporary files and atomic moves; sudo passwords travel through SSH stdin.
+- Remote Agent config and user systemd unit replacement use checked same-directory
+  temporary files and atomic moves in the SSH user's home.
 - SSH detection, deployment, Agent lifecycle, and kernel actions are CLI runtime
   adapters behind the dashboard API; they do not invoke a local management script.
-- The persisted `local` node uses the same deployment tasks and later UI flows as
-  child nodes, but its command transport executes locally with root/sudo checks
-  instead of requiring loopback SSH credentials.
+- The persisted `local` node uses the same user-level deployment tasks and later
+  UI flows as child nodes, but its command transport executes locally instead of
+  requiring loopback SSH credentials.
+- 233boy wrapper operations run directly first; only an explicit permission
+  failure may trigger sudo fallback. User-level Agent and mihomo operations never
+  request sudo.
 - Dashboard daemon start waits for `/health`; stop, uninstall, and process
   shutdown clean up the user unit and open SSE connections before exit.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,10 @@ jobs:
           gzip -dc dist/cli-release/miobridge-agent-0.0.0-ci-linux-x64.gz > "$RUNNER_TEMP/miobridge-agent"
           chmod 0755 "$RUNNER_TEMP/miobridge-agent"
           test "$("$RUNNER_TEMP/miobridge-agent" --version)" = 0.0.0-ci
+          sh -n dist/cli-release/install.sh
+          grep -F 'install.sh' dist/cli-release/SHA256SUMS
+          sh -n dist/cli-release/install-agent.sh
+          grep -F 'install-agent.sh' dist/cli-release/SHA256SUMS
 
   build:
     name: Build (Vite SPA)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,8 @@ jobs:
           gzip -dc "dist/cli-release/miobridge-agent-$RELEASE_VERSION-linux-x64.gz" > "$RUNNER_TEMP/miobridge-agent"
           chmod 0755 "$RUNNER_TEMP/miobridge-agent"
           test "$("$RUNNER_TEMP/miobridge-agent" --version)" = "$RELEASE_VERSION"
+          sh -n dist/cli-release/install.sh
+          grep -F 'install.sh' dist/cli-release/SHA256SUMS
           sh -n dist/cli-release/install-agent.sh
           grep -F 'install-agent.sh' dist/cli-release/SHA256SUMS
           test -s dist/cli-release/SHA256SUMS
@@ -119,5 +121,6 @@ jobs:
           files: |
             dist/cli-release/miobridge-*.tar.gz
             dist/cli-release/miobridge-agent-*.gz
+            dist/cli-release/install.sh
             dist/cli-release/install-agent.sh
             dist/cli-release/SHA256SUMS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 本文档记录 MioBridge 的重要变更。版本号遵循语义化版本规范。
 
+## [1.2.3] — 2026-07-19
+
+### Fixed
+
+- Agent 部署与协议内核安装解耦：部署 Agent 只监控已安装且配置可读的内核，
+  不再因预选 sing-box、Xray 或 V2Ray 而自动安装它们。
+- Agent 与 mihomo 改为用户目录和用户级 systemd 生命周期，安装、升级、启停与
+  卸载不再要求 sudo；手动 `install-agent.sh` 也默认以当前用户运行。
+- 233boy 内核 wrapper 的维护命令优先直接执行；只有输出明确表示权限不足时才
+  尝试 sudo 回退，避免受 `NoNewPrivileges` 限制的 Dashboard 无故提权失败。
+- Release assets 同时发布并校验 `install.sh` 与 `install-agent.sh`。
+
 ## [1.2.2] — 2026-07-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ curl -fsSL https://raw.githubusercontent.com/imal1/MioBridge/main/scripts/instal
 
 The bootstrap installs the verified Linux CLI, static dashboard, and pinned
 runtime dependencies. By default it registers this server as the local node and
-installs the matching Agent configured to monitor sing-box, Xray, and V2Ray;
-pass `--no-local-node` to skip both. It does not clone or build the source tree.
-Runtime files live under `~/.config/miobridge/`.
+installs the matching user-level Agent. The Agent monitors only protocol kernels
+that are already installed and readable; deploying it never installs sing-box,
+Xray, or V2Ray. Pass `--no-local-node` to skip the local node and Agent. It does
+not clone or build the source tree. Runtime files live under
+`~/.config/miobridge/`.
 
 ## CLI
 
@@ -108,18 +110,23 @@ clients. The CLI binary owns the API and static-file server.
 When adding or editing a child node, MioBridge first detects sing-box, Xray,
 and V2Ray over SSH. The selection dialog shows the installed version and
 default configuration path for each kernel. Select at least one kernel;
-selected missing kernels are installed during deployment, while installed but
-unselected kernels remain visible as unmonitored.
+Agent deployment keeps only installed kernels whose configuration is readable.
+Missing kernels are never installed as a side effect; install one explicitly
+from its kernel action when needed. Installed but unselected kernels remain
+visible as unmonitored.
 
 Protocol-kernel lifecycle operations delegate to the upstream 233boy
 management scripts (`233boy/sing-box`, `233boy/Xray`, and `233boy/v2ray`).
 MioBridge detects the management wrapper at `/usr/local/bin/<kernel>` and uses
 the script-managed configuration under `/etc/<kernel>`; a bare upstream core
 binary is not treated as a compatible source provider because it has no
-`url [name]` command.
+`url [name]` command. Lifecycle commands call the global wrapper directly and
+fall back to sudo only when the wrapper explicitly reports insufficient
+permissions.
 
 The CLI selects a same-version x64/arm64 Agent Release asset for the child,
-verifies it against `SHA256SUMS`, and installs it without Git, Bun, or a source build.
+verifies it against `SHA256SUMS`, and installs it under the SSH user's home with
+a `systemctl --user` service. This requires no sudo, Git, Bun, or source build.
 
 The Agent config uses an ordered `kernels` list, so one child can publish
 structured sources from several runtimes:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,7 +13,8 @@ curl -fsSL https://raw.githubusercontent.com/imal1/MioBridge/main/scripts/instal
 ```
 
 引导脚本安装经过校验的 Linux CLI、静态仪表盘和固定版本运行依赖；默认把当前
-服务器登记为本机节点，并安装监控 sing-box、Xray、V2Ray 的同版本 Agent。使用
+服务器登记为本机节点，并安装同版本的用户态 Agent。Agent 只监听已经安装且
+配置可读的协议内核；部署 Agent 不会安装 sing-box、Xray 或 V2Ray。使用
 `--no-local-node` 可跳过本机节点和 Agent。安装过程不会克隆或构建源码仓库，
 运行数据位于 `~/.config/miobridge/`。
 
@@ -104,15 +105,20 @@ CLI 通信。CLI 二进制统一负责 API 与静态文件服务。
 
 新增或编辑子节点时，MioBridge 会先通过 SSH 检测 sing-box、Xray 和 V2Ray。
 选择对话框会分别显示各内核的已安装版本与默认配置路径。至少选择一个内核；
-已选择但缺失的内核会在部署阶段安装，已安装但未选择的内核仍会显示为"未监听"。
+Agent 部署只保留已安装且配置可读的内核，缺失内核绝不会随 Agent 自动安装；
+需要时必须通过对应内核的安装操作明确安装。已安装但未选择的内核仍显示为
+“未监听”。
 
 协议内核的安装、升级、修复、重装和卸载统一委托给上游 233boy 管理脚本
 （`233boy/sing-box`、`233boy/Xray`、`233boy/v2ray`）。MioBridge 检测
 `/usr/local/bin/<内核>` 管理入口并读取 `/etc/<内核>` 下的配置；只有官方裸内核、
 但没有 `url [name]` 命令时，不会被误判为可用的节点来源。
+维护操作会先直接调用这个全局 wrapper；只有 wrapper 明确报告权限不足时才回退
+到 sudo。
 
 CLI 会为子节点选择同版本的 x64/arm64 Agent Release 制品，使用
-`SHA256SUMS` 校验后安装；子节点不需要 Git、Bun 或源码构建。
+`SHA256SUMS` 校验后安装到 SSH 用户目录，并通过 `systemctl --user` 管理；该流程
+不需要 sudo、Git、Bun 或源码构建。
 
 Agent 配置使用有序的 `kernels` 列表，因此同一个子节点可以发布多个运行时的
 结构化来源：

--- a/agent/agent.yaml.example
+++ b/agent/agent.yaml.example
@@ -1,5 +1,5 @@
 # MioBridge Agent 配置文件
-# 部署到 /etc/miobridge-agent/agent.yaml
+# 部署到 ~/.config/miobridge-agent/agent.yaml
 
 node:
   id: "node-sg"          # 节点唯一标识
@@ -13,6 +13,6 @@ kernels:
     configPath: "/etc/xray/config.json"
 
 mihomo:
-  path: "/usr/local/bin/mihomo"
+  path: "mihomo"
 
 port: 3001

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miobridge-agent",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/agent/src/__tests__/handlers.test.ts
+++ b/agent/src/__tests__/handlers.test.ts
@@ -304,7 +304,7 @@ describe('handleHealth', () => {
     const body = await res.json();
     expect(body.uptime).toBeDefined();
     expect(body.memory).toBeDefined();
-    expect(body.version).toBe('1.2.2');
+    expect(body.version).toBe('1.2.3');
   });
 });
 

--- a/agent/src/__tests__/installer.test.ts
+++ b/agent/src/__tests__/installer.test.ts
@@ -63,6 +63,7 @@ function fixture(machine = 'x86_64') {
   writeFileSync(join(fakeBin, 'systemctl'), [
     '#!/bin/sh',
     'printf "%s\\n" "$*" >> "$FAKE_SYSTEMCTL_LOG"',
+    '[ "$1" != "--user" ] || shift',
     'case "$1" in',
     '  is-active) test -f "$FAKE_ACTIVE" ;;',
     '  restart) test ! -f "$FAKE_FAIL_RESTART" || exit 1; touch "$FAKE_ACTIVE" ;;',
@@ -95,7 +96,6 @@ function fixture(machine = 'x86_64') {
   const env = {
     ...process.env,
     PATH: `${fakeBin}:${process.env.PATH}`,
-    MIOBRIDGE_AGENT_ALLOW_NON_ROOT: '1',
     MIOBRIDGE_AGENT_UNIT_PATH: unitPath,
     MIOBRIDGE_AGENT_SYSTEMCTL: 'systemctl',
     FAKE_SYSTEMCTL_LOG: systemctlLog,
@@ -118,6 +118,23 @@ function installArgs(context: ReturnType<typeof fixture>, extra: string[] = []):
 }
 
 describe('install-agent.sh', () => {
+  test('uses current-user binary, config, and user systemd paths by default', () => {
+    const context = fixture();
+    const userHome = join(context.directory, 'home');
+    const xdgConfig = join(context.directory, 'xdg');
+    const { MIOBRIDGE_AGENT_UNIT_PATH: _unitPath, ...env } = context.env;
+    execFileSync('sh', [
+      installer,
+      '--version', '1.2.3',
+      '--base-url', `file://${context.release}`,
+      '--config', context.config,
+    ], { env: { ...env, HOME: userHome, XDG_CONFIG_HOME: xdgConfig } });
+
+    expect(execFileSync(join(userHome, '.local', 'bin', 'miobridge-agent'), ['--version'], { encoding: 'utf8' }).trim()).toBe('1.2.3');
+    expect(readFileSync(join(userHome, '.config', 'miobridge-agent', 'agent.yaml'), 'utf8')).toContain('id: "node-1"');
+    expect(readFileSync(join(xdgConfig, 'systemd', 'user', 'miobridge-agent.service'), 'utf8')).toContain('WantedBy=default.target');
+  });
+
   test.each([['x86_64', 'x64'], ['amd64', 'x64'], ['aarch64', 'arm64'], ['arm64', 'arm64']])(
     'maps %s to the %s release and installs an explicit-config systemd unit',
     (machine) => {
@@ -130,8 +147,9 @@ describe('install-agent.sh', () => {
       expect(output).toContain('MioBridge Agent 1.2.3 installed');
       expect(execFileSync(binary, ['--marker'], { encoding: 'utf8' }).trim()).toBe('initial');
       expect(readFileSync(context.unitPath, 'utf8')).toContain(`ExecStart="${binary}" --config "${join(context.configDir, 'agent.yaml')}"`);
-      expect(readFileSync(context.systemctlLog, 'utf8')).toContain('daemon-reload');
-      expect(readFileSync(context.systemctlLog, 'utf8')).toContain('restart miobridge-agent');
+      expect(readFileSync(context.unitPath, 'utf8')).toContain('WantedBy=default.target');
+      expect(readFileSync(context.systemctlLog, 'utf8')).toContain('--user daemon-reload');
+      expect(readFileSync(context.systemctlLog, 'utf8')).toContain('--user restart miobridge-agent');
     },
   );
 

--- a/agent/src/config.ts
+++ b/agent/src/config.ts
@@ -41,7 +41,7 @@ export function getDefaultConfig(): AgentConfig {
   return {
     node: { id: '', name: '', secret: '' },
     kernels: [{ type: 'sing-box', configPath: '/etc/sing-box/config.json' }],
-    mihomo: { path: '/usr/local/bin/mihomo' },
+    mihomo: { path: 'mihomo' },
     port: 3001,
   };
 }

--- a/agent/src/handlers/logs.ts
+++ b/agent/src/handlers/logs.ts
@@ -34,21 +34,28 @@ function filterLines(lines: string[], level: string, query: string): string[] {
 }
 
 function readJournalLines(): string[] {
-  try {
-    const output = execSync('journalctl -u miobridge-agent -n 800 --no-pager --output=short-iso', {
-      encoding: 'utf8',
-      timeout: 5000,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-    return output.split(/\r?\n/).filter(Boolean);
-  } catch (error: any) {
-    const message = error?.stderr || error?.message || 'journalctl unavailable';
-    return [`journalctl 暂不可用: ${String(message).trim()}`];
+  let lastError = 'journalctl unavailable';
+  for (const command of [
+    'journalctl --user -u miobridge-agent.service -n 800 --no-pager --output=short-iso',
+    'journalctl -u miobridge-agent.service -n 800 --no-pager --output=short-iso',
+  ]) {
+    try {
+      const output = execSync(command, {
+        encoding: 'utf8', timeout: 5000, stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      const lines = output.split(/\r?\n/).filter(Boolean);
+      if (lines.length > 0) return lines;
+    } catch (error: any) {
+      lastError = String(error?.stderr || error?.message || lastError).trim();
+    }
   }
+  return [`journalctl 暂不可用: ${lastError}`];
 }
 
 function readAgentLogLines(): string[] {
   const candidates = [
+    `${process.env.HOME || ''}/.local/share/miobridge-agent/agent.log`,
+    `${process.env.HOME || ''}/.config/miobridge-agent/agent.log`,
     '/var/log/miobridge-agent.log',
     '/etc/miobridge-agent/agent.log',
   ];

--- a/agent/src/version.ts
+++ b/agent/src/version.ts
@@ -1,1 +1,1 @@
-export const AGENT_VERSION = process.env.MIOBRIDGE_BUILD_VERSION ?? '1.2.2';
+export const AGENT_VERSION = process.env.MIOBRIDGE_BUILD_VERSION ?? '1.2.3';

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -22,8 +22,9 @@ GitHub Release, verifies SHA-256, then atomically installs
 `~/.local/bin/miobridge` and the static dashboard under
 `~/.config/miobridge/dist/dashboard`, then runs
 `miobridge setup --yes --local-node` to install pinned runtime dependencies,
-persist this server as the local node, and install the matching Agent configured
-to monitor sing-box, Xray, and V2Ray from its checksum-covered release installer.
+persist this server as the local node, and install the matching user-level Agent.
+Agent deployment monitors only already-installed, readable protocol kernels and
+never installs sing-box, Xray, or V2Ray as a side effect.
 Pass `--no-local-node` to skip the local node and Agent. It needs `curl` or
 `wget`, `tar`, and `sha256sum` (or `shasum`).
 It does not require Git, Node.js, Bun, or a source checkout.
@@ -102,26 +103,33 @@ Exact versions, URLs, and SHA-256 values are reviewed source in
 [`packages/cli/src/setup/catalog.ts`](../packages/cli/src/setup/catalog.ts).
 Setup redacts credentials and query secrets from errors.
 
+Explicit protocol-kernel actions use the installed 233boy
+`/usr/local/bin/<kernel>` wrapper. MioBridge runs that wrapper directly first;
+it retries through sudo only when the command explicitly reports a permission
+failure. Detection and ordinary successful lifecycle commands do not request
+sudo.
+
 Remote Agent deployment follows the same layering: the CLI selects the
 same-version x64/arm64 compressed Agent asset, verifies `SHA256SUMS`, and installs
-the binary on the child without installing Bun or compiling source.
+the binary under the SSH user's home with a `systemctl --user` service. It needs
+no sudo and does not install Bun, compile source, or install a protocol kernel.
 
 For a manual child-node bootstrap, download `install-agent.sh` from the same
 GitHub Release and an `agent.yaml` from the Dashboard deployment center:
 
 ```bash
-scp agent.yaml root@child:/tmp/miobridge-agent.yaml
+scp agent.yaml child:/tmp/miobridge-agent.yaml
 curl -fsSL https://github.com/imal1/miobridge/releases/latest/download/install-agent.sh \
   -o /tmp/install-agent.sh
-sudo sh /tmp/install-agent.sh --config /tmp/miobridge-agent.yaml
+sh /tmp/install-agent.sh --config /tmp/miobridge-agent.yaml
 ```
 
-This installer owns only `/usr/local/bin/miobridge-agent`,
-`/etc/miobridge-agent/agent.yaml`, and the systemd service. It validates the
-binary and config before replacement and rolls all three files back when restart
-or local health verification fails. It never installs CLI, Dashboard, Bun,
-mihomo, or protocol kernels. See [DEPLOYMENT.md](./DEPLOYMENT.md) for independent
-parameter and mirror examples.
+This installer owns only `~/.local/bin/miobridge-agent`,
+`~/.config/miobridge-agent/agent.yaml`, and the user systemd service. It validates
+the binary and config before replacement and rolls all three files back when
+restart or local health verification fails. It never installs CLI, Dashboard,
+Bun, mihomo, or protocol kernels. See [DEPLOYMENT.md](./DEPLOYMENT.md) for
+independent parameter and mirror examples.
 
 ## Dashboard provider and systemd user service
 

--- a/docs/CLI.zh-CN.md
+++ b/docs/CLI.zh-CN.md
@@ -20,8 +20,9 @@ miobridge --version
 SHA-256 后原子安装 `~/.local/bin/miobridge` 与
 `~/.config/miobridge/dist/dashboard` 下的静态仪表盘，再执行
 `miobridge setup --yes --local-node` 安装固定版本的运行依赖、保存本机节点档案，
-并通过校验过的 `install-agent.sh` 安装监控 sing-box、Xray、V2Ray 的同版本
-Agent。传入 `--no-local-node` 可跳过本机节点与 Agent。需要 `curl` 或 `wget`、
+并安装同版本的用户态 Agent。Agent 只监听已经安装且配置可读的协议内核，部署
+Agent 不会顺带安装 sing-box、Xray 或 V2Ray。传入 `--no-local-node` 可跳过本机
+节点与 Agent。需要 `curl` 或 `wget`、
 `tar` 以及 `sha256sum`（或 `shasum`）；不需要 Git、Node.js、Bun 或源码仓库。
 
 镜像、隔离网络或非默认安装目录：
@@ -95,20 +96,25 @@ miobridge uninstall --purge
 [`packages/cli/src/setup/catalog.ts`](../packages/cli/src/setup/catalog.ts) 中。
 Setup 错误会隐藏凭据和查询参数中的密钥。
 
+明确触发协议内核操作时，MioBridge 会先直接调用已经安装的 233boy
+`/usr/local/bin/<内核>` wrapper；只有命令明确报告权限不足时才通过 sudo 重试。
+检测及可直接成功的日常启停、升级等操作不会请求 sudo。
+
 远端 Agent 也遵循同一分层：CLI 选择同版本的 x64/arm64 压缩 Agent 制品，
-校验 `SHA256SUMS` 后安装到子节点，不安装 Bun，也不编译源码。
+校验 `SHA256SUMS` 后安装到 SSH 用户目录并由 `systemctl --user` 管理。该流程
+不需要 sudo，不安装 Bun、不编译源码，也不安装任何协议内核。
 
 子节点也可以从部署中心下载 `agent.yaml`，再使用同一个 Release 内的独立安装器：
 
 ```bash
-scp agent.yaml root@child:/tmp/miobridge-agent.yaml
+scp agent.yaml child:/tmp/miobridge-agent.yaml
 curl -fsSL https://github.com/imal1/miobridge/releases/latest/download/install-agent.sh \
   -o /tmp/install-agent.sh
-sudo sh /tmp/install-agent.sh --config /tmp/miobridge-agent.yaml
+sh /tmp/install-agent.sh --config /tmp/miobridge-agent.yaml
 ```
 
-该脚本只管理 `/usr/local/bin/miobridge-agent`、
-`/etc/miobridge-agent/agent.yaml` 和 systemd unit。它会依次校验 checksum、
+该脚本只管理 `~/.local/bin/miobridge-agent`、
+`~/.config/miobridge-agent/agent.yaml` 和用户级 systemd unit。它会依次校验 checksum、
 执行 `--version`、执行 `--check-config`、原子替换文件、重启服务并检查本机
 `/health`；启动或健康检查失败会恢复原二进制、配置与 unit。它不安装主 CLI、
 Dashboard、Bun、mihomo 或任何协议核心。镜像与独立参数模式见

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -55,22 +55,22 @@ are documented in [CLI.md](./CLI.md). They retain state under the user's
 ## Child-node Agent bootstrap
 
 Child nodes use the separate `install-agent.sh` release asset. It installs only
-the checksum-verified x64/arm64 Agent binary, `/etc/miobridge-agent/agent.yaml`,
-and `miobridge-agent.service`. It does not install the main CLI, Dashboard, Bun,
-mihomo, or a protocol kernel, and it does not register a node in the control
-plane.
+the checksum-verified x64/arm64 Agent binary under `~/.local/bin`, its config
+under `~/.config/miobridge-agent`, and a `systemctl --user` service. It needs no
+sudo. It does not install the main CLI, Dashboard, Bun, mihomo, or a protocol
+kernel, and it does not register a node in the control plane.
 
 Download `agent.yaml` from the Dashboard deployment center, copy it to the child,
 then run:
 
 ```bash
-scp agent.yaml root@child:/tmp/miobridge-agent.yaml
+scp agent.yaml child:/tmp/miobridge-agent.yaml
 
 curl -fsSL \
   https://github.com/imal1/miobridge/releases/latest/download/install-agent.sh \
   -o /tmp/install-agent.sh
 
-sudo sh /tmp/install-agent.sh --config /tmp/miobridge-agent.yaml
+sh /tmp/install-agent.sh --config /tmp/miobridge-agent.yaml
 ```
 
 The installer verifies `SHA256SUMS`, runs the binary's `--version` and
@@ -82,12 +82,12 @@ same version is an idempotent reinstall/repair.
 For an offline mirror or a config assembled on the child:
 
 ```bash
-sudo sh install-agent.sh \
+sh install-agent.sh \
   --version 1.0.0 \
   --base-url https://mirror.example/miobridge/v1.0.0 \
   --node-id node-child \
   --node-name "Child node" \
-  --secret-file /root/miobridge-agent.secret \
+  --secret-file "$HOME/.config/miobridge-agent.secret" \
   --kernel sing-box:/etc/sing-box/config.json \
   --port 3001
 ```
@@ -95,3 +95,9 @@ sudo sh install-agent.sh \
 Omit every `--kernel` to generate `kernels: []`. Plaintext `--secret` is not
 accepted. After installation, runtime maintenance belongs to the Dashboard/API;
 the shell script remains a bootstrap and repair entrypoint only.
+
+Dashboard Agent deployment has the same boundary: it includes only kernels that
+are already installed and readable, and never installs a selected-but-missing
+kernel. Protocol-kernel install and maintenance remain explicit operations.
+233boy lifecycle commands run their global wrapper directly; MioBridge attempts
+sudo only if that wrapper explicitly reports a permissions error.

--- a/docs/FRONTEND-FUNCTIONAL-CLOSURE-PRD.zh-CN.md
+++ b/docs/FRONTEND-FUNCTIONAL-CLOSURE-PRD.zh-CN.md
@@ -389,13 +389,13 @@ GET /api/deployments/agent/manual-config?nodeId=<id>
 使用方式：
 
 ```bash
-scp agent.yaml root@child:/tmp/miobridge-agent.yaml
+scp agent.yaml <ssh-user>@child:/tmp/miobridge-agent.yaml
 
 curl -fsSL \
   https://github.com/imal1/miobridge/releases/latest/download/install-agent.sh \
   -o /tmp/install-agent.sh
 
-sudo sh /tmp/install-agent.sh \
+sh /tmp/install-agent.sh \
   --config /tmp/miobridge-agent.yaml
 ```
 
@@ -414,7 +414,7 @@ install-agent.sh \
 以及独立参数模式：
 
 ```bash
-sudo sh install-agent.sh \
+sh install-agent.sh \
   --node-id <id> \
   --node-name <name> \
   --secret-file <file> \
@@ -430,7 +430,7 @@ sudo sh install-agent.sh \
 - x86_64/amd64 映射 x64，aarch64/arm64 映射 arm64。
 - 下载 Agent gzip 和 `SHA256SUMS`，执行 checksum、`--version`、`--check-config`。
 - 原子替换二进制、配置和 systemd unit；失败恢复旧文件。
-- unit 显式使用 `--config /etc/miobridge-agent/agent.yaml`。
+- user unit 显式使用 `--config ~/.config/miobridge-agent/agent.yaml`。
 - 验证 systemd active 与本机 `/health`。
 - 只安装 Agent，不安装 CLI、Dashboard、Bun、mihomo 或协议核心。
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miobridge",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "MioBridge — sing-box to Clash subscription converter powered by mihomo, supporting vless/vmess/trojan/hysteria2/tuic",
   "private": true,
   "packageManager": "bun@1.2.13",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miobridge/cli",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -8,7 +8,7 @@ import { formatLocalNodeConfiguration, type LocalNodeConfigurationService } from
 import { formatDashboardDaemonStatus, type DashboardDaemonAction } from './dashboard/commands.js';
 import type { DashboardDaemonStatus } from './dashboard/systemd.js';
 
-export const CLI_VERSION = process.env.MIOBRIDGE_BUILD_VERSION ?? '1.2.2';
+export const CLI_VERSION = process.env.MIOBRIDGE_BUILD_VERSION ?? '1.2.3';
 
 export interface CliCore {
   updateSubscription(): Promise<UpdateResult>;

--- a/packages/cli/src/dashboard/server/nodeDependencies.ts
+++ b/packages/cli/src/dashboard/server/nodeDependencies.ts
@@ -234,7 +234,7 @@ export function createNodeDashboardDependencies(composition: NodeCoreComposition
           const mihomo = {
             nodeId: node.nodeId, component: 'mihomo',
             ...taskState(node.nodeId, 'mihomo', node.mihomoAvailable ? 'installed' : node.online ? 'not_installed' : 'unknown'),
-            runtimeState: 'not_applicable', monitorState: 'not_applicable', path: '/usr/local/bin/mihomo',
+            runtimeState: 'not_applicable', monitorState: 'not_applicable', path: '~/.config/miobridge/bin/mihomo',
             ...(node.mihomoVersion ? { version: node.mihomoVersion } : {}),
           };
           const kernels = node.kernels.map(kernel => ({

--- a/packages/cli/src/dashboard/server/sshDeployment.ts
+++ b/packages/cli/src/dashboard/server/sshDeployment.ts
@@ -4,7 +4,6 @@ import { randomUUID } from 'node:crypto';
 import { spawn } from 'node:child_process';
 import { lookup } from 'node:dns/promises';
 import { createConnection, isIP } from 'node:net';
-import { posix } from 'node:path';
 import {
   KERNEL_TYPES,
   validateNodeKernels,
@@ -25,9 +24,13 @@ import {
   wrapperCommand,
 } from './kernelScripts.js';
 
-const AGENT_REMOTE_PATH = '/usr/local/bin/miobridge-agent';
-const AGENT_CONFIG_PATH = '/etc/miobridge-agent/agent.yaml';
-const AGENT_SERVICE_PATH = '/etc/systemd/system/miobridge-agent.service';
+const AGENT_USER_BIN = '$HOME/.local/bin/miobridge-agent';
+const AGENT_USER_CONFIG = '$HOME/.config/miobridge-agent/agent.yaml';
+const AGENT_USER_UNIT = '$HOME/.config/systemd/user/miobridge-agent.service';
+const LEGACY_AGENT_PATH = '/usr/local/bin/miobridge-agent';
+const LEGACY_AGENT_CONFIG_PATH = '/etc/miobridge-agent/agent.yaml';
+const LEGACY_AGENT_SERVICE_PATH = '/etc/systemd/system/miobridge-agent.service';
+const MIHOMO_USER_PATH = '$HOME/.config/miobridge/bin/mihomo';
 const PROGRESS_TTL_MS = 10 * 60 * 1000;
 const TASK_HISTORY_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 
@@ -143,6 +146,11 @@ function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
+function userSystemctl(...args: readonly string[]): string {
+  const command = ['systemctl', '--user', ...args].map(shellQuote).join(' ');
+  return `XDG_RUNTIME_DIR=\"\${XDG_RUNTIME_DIR:-/run/user/$(id -u)}\" ${command}`;
+}
+
 function validatePrivateKey(value: string): void {
   if (Buffer.byteLength(value, 'utf8') > 64 * 1024) throw new Error('SSH 私钥不能超过 64 KiB');
   const trimmed = value.trim();
@@ -181,6 +189,7 @@ export class SshDeploymentService {
     checks: Array<{ key: string; label: string; ok: boolean; detail: string }>;
   }> {
     const input = inputObject(body);
+    const component = typeof input.component === 'string' ? this.deployComponent(input.component) : 'agent';
     const target = typeof input.nodeId === 'string'
       ? await this.targetForNode(input.nodeId)
       : await this.targetFromSsh(inputObject(input.ssh));
@@ -203,13 +212,19 @@ export class SshDeploymentService {
     }
     const ssh = await this.connect(target);
     try {
+      const needsUserSystemd = component === 'agent';
+      const needsSystemd = component !== 'mihomo';
       const [system, architecture, disk, systemd, downloader, privilege] = await Promise.all([
         this.exec(ssh, 'uname -s'),
         this.exec(ssh, 'uname -m'),
         this.exec(ssh, "df -Pk / | awk 'NR==2 {print $4}'"),
-        this.exec(ssh, 'command -v systemctl'),
+        !needsSystemd
+          ? Promise.resolve({ stdout: '', stderr: '', code: 0 })
+          : needsUserSystemd
+          ? this.exec(ssh, userSystemctl('show-environment'))
+          : this.exec(ssh, 'command -v systemctl'),
         this.exec(ssh, 'command -v curl || command -v wget'),
-        this.execRoot(ssh, target, 'true'),
+        Promise.resolve({ stdout: '', stderr: '', code: 0 }),
       ]);
       const freeKb = Number(disk.stdout.trim());
       const checks = [
@@ -219,9 +234,9 @@ export class SshDeploymentService {
         { key: 'system', label: 'Linux 系统', ok: system.code === 0 && system.stdout.trim() === 'Linux', detail: system.stdout.trim() || system.stderr.trim() },
         { key: 'architecture', label: 'CPU 架构', ok: /^(x86_64|amd64|aarch64|arm64)$/.test(architecture.stdout.trim()), detail: architecture.stdout.trim() || architecture.stderr.trim() },
         { key: 'disk', label: '磁盘空间', ok: Number.isFinite(freeKb) && freeKb >= 200 * 1024, detail: Number.isFinite(freeKb) ? `${Math.round(freeKb / 1024)} MiB 可用` : '无法读取' },
-        { key: 'systemd', label: 'systemd', ok: systemd.code === 0, detail: systemd.stdout.trim() || '未找到' },
+        { key: 'systemd', label: needsUserSystemd ? '用户级 systemd' : 'systemd', ok: systemd.code === 0, detail: !needsSystemd ? 'mihomo 用户态安装不需要 systemd' : systemd.code === 0 ? (needsUserSystemd ? 'systemctl --user 可用' : systemd.stdout.trim()) : (systemd.stderr || systemd.stdout).trim() || '未找到' },
         { key: 'download', label: '下载工具', ok: downloader.code === 0, detail: downloader.stdout.trim() || '未找到 curl/wget' },
-        { key: 'privilege', label: '管理员权限', ok: privilege.code === 0, detail: privilege.code === 0 ? 'root/sudo 可用' : (privilege.stderr || privilege.stdout).trim() },
+        { key: 'privilege', label: '执行权限', ok: privilege.code === 0, detail: KERNEL_TYPES.includes(component as KernelType) ? '优先直接调用 233boy 全局 wrapper；仅在明确权限不足时提权回退' : '此组件使用用户态部署，无需 sudo' },
       ];
       return { hostKey: target.ssh.hostKey, architecture: architecture.stdout.trim(), checks };
     } finally { ssh.end(); }
@@ -396,16 +411,29 @@ export class SshDeploymentService {
     const target = await this.targetForNode(nodeId);
     const ssh = await this.connect(target);
     try {
-      const command = action === 'uninstall'
+      const userCommand = action === 'uninstall'
+        ? [
+            `${userSystemctl('disable', '--now', 'miobridge-agent.service')} 2>/dev/null || true`,
+            `rm -f \"${AGENT_USER_BIN}\" \"${AGENT_USER_UNIT}\"`,
+            ...(options.preserveConfig ? [] : [`rm -rf \"$HOME/.config/miobridge-agent\"`]),
+            ...(options.preserveData ? [] : [`rm -rf \"$HOME/.local/share/miobridge-agent\"`]),
+            userSystemctl('daemon-reload'),
+          ].join(' && ')
+        : userSystemctl(action, 'miobridge-agent.service');
+      const userAgent = await this.exec(ssh, `test -x \"${AGENT_USER_BIN}\"`);
+      const legacyAgent = await this.exec(ssh, `test -x ${shellQuote(LEGACY_AGENT_PATH)} || test -f ${shellQuote(LEGACY_AGENT_SERVICE_PATH)}`);
+      const legacyCommand = action === 'uninstall'
         ? [
             'systemctl disable --now miobridge-agent 2>/dev/null || true',
-            `rm -f ${AGENT_REMOTE_PATH} ${AGENT_SERVICE_PATH}`,
+            `rm -f ${shellQuote(LEGACY_AGENT_PATH)} ${shellQuote(LEGACY_AGENT_SERVICE_PATH)}`,
             ...(options.preserveConfig ? [] : ['rm -rf /etc/miobridge-agent']),
             ...(options.preserveData ? [] : ['rm -rf /var/lib/miobridge-agent']),
             'systemctl daemon-reload',
           ].join(' && ')
         : `systemctl ${action} miobridge-agent`;
-      const executed = await this.execRoot(ssh, target, command);
+      const executed = userAgent.code === 0 || legacyAgent.code !== 0
+        ? await this.exec(ssh, userCommand)
+        : await this.execRoot(ssh, target, legacyCommand);
       if (executed.code !== 0) throw new Error((executed.stderr || executed.stdout).trim() || `Agent ${action} 失败`);
       await this.composition.repository.update(nodeId, node => ({
         ...node,
@@ -439,7 +467,7 @@ export class SshDeploymentService {
     const target = await this.targetForNode(nodeId);
     const ssh = await this.connect(target);
     try {
-      const executed = await this.execRoot(ssh, target, uninstallCommand(type, options.preserveConfig));
+      const executed = await this.execWithPrivilegeFallback(ssh, target, uninstallCommand(type, options.preserveConfig));
       if (executed.code !== 0) throw new Error((executed.stderr || executed.stdout).trim() || `${type} 卸载失败`);
       return await this.detectKernel(ssh, type);
     } finally {
@@ -454,7 +482,7 @@ export class SshDeploymentService {
     const target = await this.targetForNode(nodeId);
     const ssh = await this.connect(target);
     try {
-      const executed = await this.execRoot(ssh, target, wrapperCommand(type, action));
+      const executed = await this.execWithPrivilegeFallback(ssh, target, wrapperCommand(type, action));
       if (executed.code !== 0) throw new Error((executed.stderr || executed.stdout).trim() || `${type} ${action} 失败`);
       return { nodeId, kernelType: type, status: action === 'stop' ? 'stopped' : 'running' };
     } finally { ssh.end(); }
@@ -488,10 +516,11 @@ export class SshDeploymentService {
         'gzip -dc "$workdir/mihomo.gz" > "$workdir/mihomo"',
         'chmod 755 "$workdir/mihomo"',
         `"$workdir/mihomo" -v | grep -F ${shellQuote(artifact.version.replace(/^v/, ''))} >/dev/null`,
-        'install -m 755 "$workdir/mihomo" /usr/local/bin/mihomo',
+        'mkdir -p "$HOME/.config/miobridge/bin"',
+        `install -m 755 "$workdir/mihomo" \"${MIHOMO_USER_PATH}\"`,
       ].join('\n');
       const command = `URL=${shellQuote(artifact.url)} SHA256=${shellQuote(artifact.sha256)} bash -c ${shellQuote(script)}`;
-      const installed = await this.execRoot(ssh, target, command);
+      const installed = await this.exec(ssh, command);
       if (installed.code !== 0) throw new Error(`mihomo 安装失败: ${(installed.stderr || installed.stdout).trim().slice(-600)}`);
       return await this.detectMihomoOn(ssh);
     } finally { ssh.end(); }
@@ -501,7 +530,10 @@ export class SshDeploymentService {
     const target = await this.targetForNode(nodeId);
     const ssh = await this.connect(target);
     try {
-      const removed = await this.execRoot(ssh, target, 'rm -f /usr/local/bin/mihomo');
+      const detected = await this.detectMihomoOn(ssh);
+      const removed = detected.installed && detected.path === '/usr/local/bin/mihomo'
+        ? await this.execRoot(ssh, target, 'rm -f /usr/local/bin/mihomo')
+        : await this.exec(ssh, `rm -f \"${MIHOMO_USER_PATH}\" "$HOME/.local/bin/mihomo"`);
       if (removed.code !== 0) throw new Error((removed.stderr || removed.stdout).trim() || 'mihomo 卸载失败');
       return await this.detectMihomoOn(ssh);
     } finally { ssh.end(); }
@@ -593,7 +625,7 @@ export class SshDeploymentService {
     const ssh = await this.connect(target);
     try {
       await this.ensureKernel(ssh, target, { type });
-      const repaired = await this.execRoot(ssh, target, repairCommand(type));
+      const repaired = await this.execWithPrivilegeFallback(ssh, target, repairCommand(type));
       if (repaired.code !== 0) throw new Error((repaired.stderr || repaired.stdout).trim() || `${type} 修复检查失败`);
       return await this.detectKernel(ssh, type);
     } finally { ssh.end(); }
@@ -604,7 +636,7 @@ export class SshDeploymentService {
     const ssh = await this.connect(target);
     try {
       await this.ensureKernel(ssh, target, { type });
-      const upgraded = await this.execRoot(ssh, target, upgradeCommand(type));
+      const upgraded = await this.execWithPrivilegeFallback(ssh, target, upgradeCommand(type));
       if (upgraded.code !== 0) throw new Error((upgraded.stderr || upgraded.stdout).trim() || `${type} 升级失败`);
       return await this.detectKernel(ssh, type);
     } finally { ssh.end(); }
@@ -614,7 +646,7 @@ export class SshDeploymentService {
     const target = await this.targetForNode(nodeId);
     const ssh = await this.connect(target);
     try {
-      const reinstalled = await this.execRoot(ssh, target, reinstallCommand(type, options.preserveConfig));
+      const reinstalled = await this.execWithPrivilegeFallback(ssh, target, reinstallCommand(type, options.preserveConfig));
       if (reinstalled.code !== 0) throw new Error((reinstalled.stderr || reinstalled.stdout).trim() || `${type} 重装失败`);
       return await this.detectKernel(ssh, type);
     } finally { ssh.end(); }
@@ -644,7 +676,7 @@ export class SshDeploymentService {
     try {
       for (const kernel of kernels) {
         const path = kernel.configPath ?? DEFAULT_CONFIG_PATHS[kernel.type];
-        const checked = await this.execRoot(ssh, target, `test -r ${shellQuote(path)}`);
+        const checked = await this.exec(ssh, `test -r ${shellQuote(path)}`);
         if (checked.code !== 0) throw new Error(`${kernel.type} 监控路径不可读: ${path}`);
       }
       replaced = await this.replaceAgentConfig(ssh, target, this.agentYaml(target, kernels));
@@ -656,11 +688,11 @@ export class SshDeploymentService {
         ...(current.ssh ? { ssh: { ...current.ssh, hostKey: target.ssh.hostKey } } : {}),
         ...(current.agent ? { agent: { ...current.agent, status: 'running' as const } } : {}),
       }));
-      await this.execRoot(ssh, target, `rm -f ${shellQuote(`${AGENT_CONFIG_PATH}.rollback`)}`);
+      await this.exec(ssh, 'rm -f "$HOME/.config/miobridge-agent/agent.yaml.rollback"');
       return updated;
     } catch (error) {
       if (replaced) {
-        await this.execRoot(ssh, target, `if [ -f ${shellQuote(`${AGENT_CONFIG_PATH}.rollback`)} ]; then cp ${shellQuote(`${AGENT_CONFIG_PATH}.rollback`)} ${shellQuote(AGENT_CONFIG_PATH)}; systemctl restart miobridge-agent || true; else rm -f ${shellQuote(AGENT_CONFIG_PATH)}; systemctl stop miobridge-agent || true; fi`).catch(() => undefined);
+        await this.exec(ssh, `if [ -f "$HOME/.config/miobridge-agent/agent.yaml.rollback" ]; then cp "$HOME/.config/miobridge-agent/agent.yaml.rollback" "$HOME/.config/miobridge-agent/agent.yaml"; ${userSystemctl('restart', 'miobridge-agent.service')} || true; else rm -f "$HOME/.config/miobridge-agent/agent.yaml"; ${userSystemctl('stop', 'miobridge-agent.service')} || true; fi`).catch(() => undefined);
       }
       throw error;
     } finally {
@@ -670,20 +702,21 @@ export class SshDeploymentService {
 
   private async replaceAgentConfig(ssh: DeploymentConnection, target: SshTarget, content: string): Promise<boolean> {
     const encoded = Buffer.from(content).toString('base64');
-    const rollback = `${AGENT_CONFIG_PATH}.rollback`;
     const script = [
       'set -e',
-      `mkdir -p ${shellQuote(posix.dirname(AGENT_CONFIG_PATH))}`,
-      `tmp=$(mktemp ${shellQuote(posix.join(posix.dirname(AGENT_CONFIG_PATH), '.agent.yaml.tmp.XXXXXX'))})`,
+      'config="$HOME/.config/miobridge-agent/agent.yaml"',
+      'rollback="$config.rollback"',
+      'mkdir -p "$(dirname "$config")"',
+      'tmp=$(mktemp "$HOME/.config/miobridge-agent/.agent.yaml.tmp.XXXXXX")',
       `trap 'rm -f -- "$tmp"' EXIT`,
       `printf %s ${shellQuote(encoded)} | base64 -d > "$tmp"`,
       'chmod 600 "$tmp"',
-      `${shellQuote(AGENT_REMOTE_PATH)} --check-config "$tmp"`,
-      `if [ -f ${shellQuote(AGENT_CONFIG_PATH)} ]; then cp ${shellQuote(AGENT_CONFIG_PATH)} ${shellQuote(rollback)}; else rm -f ${shellQuote(rollback)}; fi`,
-      `mv "$tmp" ${shellQuote(AGENT_CONFIG_PATH)}`,
+      '"$HOME/.local/bin/miobridge-agent" --check-config "$tmp"',
+      'if [ -f "$config" ]; then cp "$config" "$rollback"; else rm -f "$rollback"; fi',
+      'mv "$tmp" "$config"',
       'trap - EXIT',
     ].join('\n');
-    const result = await this.execRoot(ssh, target, `bash -c ${shellQuote(script)}`);
+    const result = await this.exec(ssh, `bash -c ${shellQuote(script)}`);
     if (result.code !== 0) throw new Error(`Agent 配置校验或原子替换失败: ${(result.stderr || result.stdout).trim()}`);
     return true;
   }
@@ -710,10 +743,12 @@ export class SshDeploymentService {
       const monitored: NodeKernelConfig[] = [];
       for (const kernel of kernels) {
         emit('kernel', 'running', `检查 ${kernel.type} 内核`, 25);
-        await this.ensureKernel(ssh, target, kernel);
-        monitored.push(kernel);
+        const detected = await this.detectKernel(ssh, kernel.type);
+        const configPath = kernel.configPath ?? detected.defaultConfigPath;
+        const readable = detected.installed ? await this.exec(ssh, `test -r ${shellQuote(configPath)}`) : { code: 1 };
+        if (detected.installed && readable.code === 0) monitored.push({ ...kernel, configPath });
       }
-      emit('kernel', 'success', `${monitored.length} 个内核已就绪`, 50);
+      emit('kernel', 'success', `${monitored.length} 个已安装且可读的内核将由 Agent 监控；未安装内核不会自动安装`, 50);
 
       emit('agent', 'running', '下载并安装已校验 Agent', 60);
       await this.installAgent(ssh, target, monitored);
@@ -900,6 +935,16 @@ export class SshDeploymentService {
     return this.exec(ssh, elevated, target.ssh.password ? `${target.ssh.password}\n` : undefined);
   }
 
+  private async execWithPrivilegeFallback(ssh: DeploymentConnection, target: SshTarget, command: string): Promise<ExecResult> {
+    const direct = await this.exec(ssh, command);
+    if (direct.code === 0) return direct;
+    const output = `${direct.stdout}\n${direct.stderr}`;
+    if (!/permission denied|operation not permitted|must (?:be run|run) as root|requires? root|需要.*(?:root|管理员)|请.*root/iu.test(output)) {
+      return direct;
+    }
+    return this.execRoot(ssh, target, command);
+  }
+
   private async detectKernel(ssh: DeploymentConnection, type: KernelType): Promise<KernelDetection> {
     try {
       const definition = KERNEL_SCRIPTS[type];
@@ -926,19 +971,21 @@ export class SshDeploymentService {
 
   private async detectMihomoOn(ssh: DeploymentConnection): Promise<MihomoDetection> {
     try {
-      const result = await this.exec(ssh, '/usr/local/bin/mihomo -v 2>&1');
+      const result = await this.exec(ssh, 'for candidate in "$HOME/.config/miobridge/bin/mihomo" "$HOME/.local/bin/mihomo" /usr/local/bin/mihomo; do if [ -x "$candidate" ]; then printf "%s\\n" "$candidate"; "$candidate" -v 2>&1; exit $?; fi; done; exit 127');
       const output = (result.stdout || result.stderr).trim();
+      const [path, ...versionLines] = output.split(/\r?\n/);
+      const version = versionLines.find(line => line.trim())?.trim();
       return result.code === 0
-        ? { installed: true, path: '/usr/local/bin/mihomo', ...(output ? { version: output.split(/\r?\n/, 1)[0] } : {}) }
-        : { installed: false, path: '/usr/local/bin/mihomo', ...(output ? { error: output } : {}) };
+        ? { installed: true, path: path || MIHOMO_USER_PATH, ...(version ? { version } : {}) }
+        : { installed: false, path: MIHOMO_USER_PATH, ...(output ? { error: output } : {}) };
     } catch (error) {
-      return { installed: false, path: '/usr/local/bin/mihomo', error: error instanceof Error ? error.message : '检测失败' };
+      return { installed: false, path: MIHOMO_USER_PATH, error: error instanceof Error ? error.message : '检测失败' };
     }
   }
 
   private async ensureKernel(ssh: DeploymentConnection, target: SshTarget, kernel: NodeKernelConfig): Promise<void> {
     if ((await this.detectKernel(ssh, kernel.type)).installed) return;
-    const installed = await this.execRoot(ssh, target, installCommand(kernel.type));
+    const installed = await this.execWithPrivilegeFallback(ssh, target, installCommand(kernel.type));
     if (installed.code !== 0 && !/installed|success|生成配置文件|链接 \(URL\)|使用协议/.test(installed.stdout)) {
       throw new Error(`${kernel.type} 安装失败: ${(installed.stderr || installed.stdout).trim()}`);
     }
@@ -969,28 +1016,32 @@ export class SshDeploymentService {
       '[ "$actual" = "$expected" ]',
       'gzip -dc "$workdir/agent.gz" > "$workdir/agent"',
       `test "$(chmod 755 "$workdir/agent" && "$workdir/agent" --version)" = ${shellQuote(version)}`,
-      `mkdir -p /etc/miobridge-agent /usr/local/bin && install -m 755 "$workdir/agent" ${AGENT_REMOTE_PATH}`,
+      'mkdir -p "$HOME/.local/bin" "$HOME/.config/miobridge-agent" "$HOME/.config/systemd/user"',
+      'install -m 755 "$workdir/agent" "$HOME/.local/bin/miobridge-agent"',
     ].join('\n');
-    const installed = await this.execRoot(ssh, target, `bash -c ${shellQuote(installScript)}`);
+    const installed = await this.exec(ssh, `bash -c ${shellQuote(installScript)}`);
     if (installed.code !== 0) throw new Error(`Agent 安装或校验失败: ${(installed.stderr || installed.stdout).trim().slice(-600)}`);
-    await this.writeRemoteFile(ssh, target, AGENT_CONFIG_PATH, this.agentYaml(target, kernels), 0o600);
-    await this.writeRemoteFile(ssh, target, AGENT_SERVICE_PATH, this.systemdUnit(), 0o644);
+    await this.writeUserFile(ssh, 'miobridge-agent/agent.yaml', this.agentYaml(target, kernels), 0o600, 'config');
+    await this.writeUserFile(ssh, 'miobridge-agent.service', this.systemdUnit(), 0o644, 'unit');
   }
 
-  private async writeRemoteFile(ssh: DeploymentConnection, target: SshTarget, file: string, content: string, mode: number): Promise<void> {
-    const template = posix.join(posix.dirname(file), `.${posix.basename(file)}.tmp.XXXXXX`);
+  private async writeUserFile(ssh: DeploymentConnection, relative: string, content: string, mode: number, kind: 'config' | 'unit'): Promise<void> {
     const encoded = Buffer.from(content).toString('base64');
     const script = [
       'set -e',
-      `tmp=$(mktemp ${shellQuote(template)})`,
+      kind === 'config'
+        ? `target="$HOME/.config/${relative}"`
+        : `target="$HOME/.config/systemd/user/${relative}"`,
+      'mkdir -p "$(dirname "$target")"',
+      'tmp=$(mktemp "$(dirname "$target")/.miobridge.tmp.XXXXXX")',
       `trap 'rm -f -- "$tmp"' EXIT`,
       `printf %s ${shellQuote(encoded)} | base64 -d > "$tmp"`,
       `chmod ${mode.toString(8)} "$tmp"`,
-      `mv -- "$tmp" ${shellQuote(file)}`,
+      'mv -- "$tmp" "$target"',
       'trap - EXIT',
     ].join('\n');
-    const written = await this.execRoot(ssh, target, `bash -c ${shellQuote(script)}`);
-    if (written.code !== 0) throw new Error(`写入 ${file} 失败: ${(written.stderr || written.stdout).trim()}`);
+    const written = await this.exec(ssh, `bash -c ${shellQuote(script)}`);
+    if (written.code !== 0) throw new Error(`写入用户态 Agent 文件失败: ${(written.stderr || written.stdout).trim()}`);
   }
 
   private agentYaml(target: SshTarget, kernels: readonly NodeKernelConfig[]): string {
@@ -999,15 +1050,17 @@ export class SshDeploymentService {
       `    configPath: ${JSON.stringify(kernel.configPath ?? DEFAULT_CONFIG_PATHS[kernel.type])}`,
     ].join('\n')).join('\n');
     const kernelsBlock = kernelYaml ? `kernels:\n${kernelYaml}` : 'kernels: []';
-    return `node:\n  id: ${JSON.stringify(target.nodeId)}\n  name: ${JSON.stringify(target.nodeName)}\n  secret: ${JSON.stringify(target.secret)}\n${kernelsBlock}\nmihomo:\n  path: "/usr/local/bin/mihomo"\nport: ${target.agentPort}\n`;
+    return `node:\n  id: ${JSON.stringify(target.nodeId)}\n  name: ${JSON.stringify(target.nodeName)}\n  secret: ${JSON.stringify(target.secret)}\n${kernelsBlock}\nmihomo:\n  path: "mihomo"\nport: ${target.agentPort}\n`;
   }
 
   private systemdUnit(): string {
-    return `[Unit]\nDescription=MioBridge Agent\nAfter=network.target\n\n[Service]\nType=simple\nExecStart=${AGENT_REMOTE_PATH} --config ${AGENT_CONFIG_PATH}\nWorkingDirectory=/etc/miobridge-agent\nRestart=always\nRestartSec=5\n\n[Install]\nWantedBy=multi-user.target\n`;
+    return `[Unit]\nDescription=MioBridge Agent\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nType=simple\nExecStart=%h/.local/bin/miobridge-agent --config %h/.config/miobridge-agent/agent.yaml\nWorkingDirectory=%h/.config/miobridge-agent\nEnvironment=PATH=%h/.config/miobridge/bin:%h/.local/bin:/usr/local/bin:/usr/bin:/bin\nRestart=always\nRestartSec=5\nNoNewPrivileges=true\nPrivateTmp=true\n\n[Install]\nWantedBy=default.target\n`;
   }
 
   private async startAgent(ssh: DeploymentConnection, target: SshTarget): Promise<void> {
-    const started = await this.execRoot(ssh, target, 'systemctl daemon-reload && systemctl enable --now miobridge-agent && systemctl restart miobridge-agent');
+    const legacy = await this.exec(ssh, `test -x ${shellQuote(LEGACY_AGENT_PATH)} || test -f ${shellQuote(LEGACY_AGENT_SERVICE_PATH)} || test -f ${shellQuote(LEGACY_AGENT_CONFIG_PATH)}`);
+    if (legacy.code === 0) throw new Error('检测到旧版系统级 Agent。请先由管理员执行 "sudo systemctl disable --now miobridge-agent" 并删除旧 unit，之后重试用户态部署。');
+    const started = await this.exec(ssh, `${userSystemctl('daemon-reload')} && ${userSystemctl('enable', '--now', 'miobridge-agent.service')} && ${userSystemctl('restart', 'miobridge-agent.service')}`);
     if (started.code !== 0) throw new Error(`Agent 启动失败: ${(started.stderr || started.stdout).trim()}`);
   }
 

--- a/packages/cli/src/dashboard/systemd.ts
+++ b/packages/cli/src/dashboard/systemd.ts
@@ -55,7 +55,7 @@ export function renderDashboardUserUnit(input: {
   readonly port: number;
   readonly effectivePath: string;
 }): string {
-  return `[Unit]\nDescription=MioBridge dashboard\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nType=simple\nExecStart=${quote(input.cliPath)} dashboard foreground\nRestart=on-failure\nRestartSec=5s\nTimeoutStopSec=30s\nNoNewPrivileges=true\nPrivateTmp=true\nEnvironment=${quote(`MIOBRIDGE_CONFIG_DIR=${input.baseDir}`)}\nEnvironment=${quote(`MIOBRIDGE_DASHBOARD_HOST=${input.host}`)}\nEnvironment=${quote(`MIOBRIDGE_DASHBOARD_PORT=${input.port}`)}\nEnvironment=${quote(`PATH=${input.effectivePath}`)}\n\n[Install]\nWantedBy=default.target\n`;
+  return `[Unit]\nDescription=MioBridge dashboard\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nType=simple\nExecStart=${quote(input.cliPath)} dashboard foreground\nRestart=on-failure\nRestartSec=5s\nTimeoutStopSec=30s\nPrivateTmp=true\nEnvironment=${quote(`MIOBRIDGE_CONFIG_DIR=${input.baseDir}`)}\nEnvironment=${quote(`MIOBRIDGE_DASHBOARD_HOST=${input.host}`)}\nEnvironment=${quote(`MIOBRIDGE_DASHBOARD_PORT=${input.port}`)}\nEnvironment=${quote(`PATH=${input.effectivePath}`)}\n\n[Install]\nWantedBy=default.target\n`;
 }
 
 function output(result: CommandResult): string { return `${result.stdout}\n${result.stderr}`.trim(); }

--- a/packages/cli/src/nodes/localConfiguration.ts
+++ b/packages/cli/src/nodes/localConfiguration.ts
@@ -48,7 +48,7 @@ export class LocalNodeConfigurationService {
         type: kernel.type,
         configPath: kernel.configPath ?? DEFAULT_CONFIG_PATHS[kernel.type],
       })),
-      mihomo: { path: this.adapters.mihomoPath ?? '/usr/local/bin/mihomo' },
+      mihomo: { path: this.adapters.mihomoPath ?? 'mihomo' },
       port: node.port ?? node.agent?.port ?? 3001,
     }, { lineWidth: 0 });
   }

--- a/packages/cli/test/dashboard/ssh-deployment-release.test.ts
+++ b/packages/cli/test/dashboard/ssh-deployment-release.test.ts
@@ -46,5 +46,72 @@ describe('local deployment transport', () => {
     expect(result.checks.every(check => check.ok)).toBe(true);
     expect(result.checks.find(check => check.key === 'ssh')?.label).toBe('本机执行');
     expect(commands).toContain('uname -s');
+    expect(commands.some(command => command.includes('sudo'))).toBe(false);
+  });
+
+  it('deploys only the user Agent and never installs a missing configured kernel', async () => {
+    const commands: string[] = [];
+    let node = {
+      id: 'local', name: '本机节点', host: '127.0.0.1', secret: 'secret', location: '本机', enabled: true,
+      kernels: [{ type: 'sing-box' as const }],
+      agent: { deployed: false, version: '', status: 'not_deployed' as const, lastDeploy: '', port: 3001 },
+    };
+    const composition = {
+      repository: {
+        list: async () => [node],
+        update: async (_id: string, update: (current: typeof node) => typeof node) => {
+          node = update(node);
+          return node;
+        },
+      },
+      core: { state: { get: async () => null } },
+    } as unknown as NodeCoreComposition;
+    const service = new SshDeploymentService(composition, { runLocal: async command => {
+      commands.push(command);
+      if (command === 'uname -m') return { stdout: 'x86_64\n', stderr: '', code: 0 };
+      if (command.includes("'/usr/local/bin/sing-box' 'help'")) return { stdout: '', stderr: 'missing', code: 1 };
+      if (command.includes('/usr/local/bin/miobridge-agent') && command.startsWith('test -x')) return { stdout: '', stderr: '', code: 1 };
+      return { stdout: '', stderr: '', code: 0 };
+    } });
+
+    await service.startDeployment('local');
+    for (let attempt = 0; attempt < 50 && service.getProgress('local')?.status !== 'success'; attempt += 1) {
+      await new Promise(resolve => setTimeout(resolve, 5));
+    }
+
+    expect(service.getProgress('local')).toMatchObject({ status: 'success', step: 'done' });
+    expect(commands.some(command => command.includes('raw.githubusercontent.com/233boy'))).toBe(false);
+    expect(commands.some(command => command.includes('sudo'))).toBe(false);
+    expect(commands.some(command => command.includes('$HOME/.local/bin/miobridge-agent'))).toBe(true);
+    expect(node.kernels).toEqual([]);
+  });
+
+  it('runs an installed 233boy wrapper directly and elevates only after an explicit permission error', async () => {
+    const node = {
+      id: 'local', name: '本机节点', host: '127.0.0.1', secret: 'secret', location: '本机', enabled: true,
+      kernels: [{ type: 'sing-box' as const }],
+    };
+    const composition = {
+      repository: { list: async () => [node] },
+      core: { state: { get: async () => null } },
+    } as unknown as NodeCoreComposition;
+    const directCommands: string[] = [];
+    const direct = new SshDeploymentService(composition, { runLocal: async command => {
+      directCommands.push(command);
+      return { stdout: '', stderr: '', code: 0 };
+    } });
+    await direct.kernelAction('local', 'sing-box', 'restart');
+    expect(directCommands).toEqual(["'/usr/local/bin/sing-box' 'restart'"]);
+
+    const fallbackCommands: string[] = [];
+    const fallback = new SshDeploymentService(composition, { runLocal: async command => {
+      fallbackCommands.push(command);
+      return command.startsWith('sudo -n')
+        ? { stdout: '', stderr: '', code: 0 }
+        : { stdout: '', stderr: 'permission denied', code: 1 };
+    } });
+    await fallback.kernelAction('local', 'sing-box', 'restart');
+    expect(fallbackCommands[0]).toBe("'/usr/local/bin/sing-box' 'restart'");
+    expect(fallbackCommands[1]).toContain('sudo -n bash -lc');
   });
 });

--- a/packages/cli/test/dashboard/systemd.test.ts
+++ b/packages/cli/test/dashboard/systemd.test.ts
@@ -60,7 +60,7 @@ describe('dashboard systemd user lifecycle', () => {
     expect(unit).toContain('Environment="MIOBRIDGE_DASHBOARD_PORT=3000"');
     expect(unit).toContain('Restart=on-failure');
     expect(unit).toContain('Environment="PATH=/managed/bin:/usr/bin"');
-    expect(unit).toContain('NoNewPrivileges=true');
+    expect(unit).not.toContain('NoNewPrivileges=');
     expect(unit).not.toContain('PIDFile');
   });
 

--- a/packages/cli/test/headless.test.ts
+++ b/packages/cli/test/headless.test.ts
@@ -64,7 +64,7 @@ describe('headless CLI composition', () => {
     });
     expect(result.code).toBe(0);
     expect(result.stderr).toBe('');
-    expect(JSON.parse(result.stdout)).toMatchObject({ version: '1.2.2', subscriptionExists: false });
+    expect(JSON.parse(result.stdout)).toMatchObject({ version: '1.2.3', subscriptionExists: false });
     expect(await readdir(cwd)).toEqual(['.keep']);
     await rm(sandbox, { recursive: true, force: true });
   });

--- a/packages/cli/test/release/release.test.ts
+++ b/packages/cli/test/release/release.test.ts
@@ -85,6 +85,7 @@ describe('CLI release distribution', () => {
     writeFileSync(join(coreDir, 'dist', 'stale.js'), 'stale');
     writeFileSync(join(sandbox, 'packages', 'cli', 'src', 'main.ts'), 'fixture');
     copyFileSync(packageScript, sandboxScript);
+    copyFileSync(installer, join(sandbox, 'scripts', 'install.sh'));
     writeFileSync(fakeBun, [
       '#!/bin/sh',
       'set -eu',
@@ -132,6 +133,10 @@ describe('CLI release distribution', () => {
       expect(binaryLine?.startsWith('-rwx')).toBe(true);
       expect(statSync(join(release, `miobridge-agent-1.2.3-linux-${arch}.gz`)).size).toBeGreaterThan(0);
     }
+    expect(sums).toContain('install.sh');
+    expect(sums).toContain('install-agent.sh');
+    expect(statSync(join(release, 'install.sh')).mode & 0o111).not.toBe(0);
+    expect(statSync(join(release, 'install-agent.sh')).mode & 0o111).not.toBe(0);
   });
 
   it.each([['x86_64', 'x64'], ['aarch64', 'arm64']])('maps %s and installs from an external cwd', (machine, expected) => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miobridge/core",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miobridge/e2e",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miobridge/frontend",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Dashboard for MioBridge \u2014 sing-box to Clash converter powered by mihomo",
   "private": true,
   "packageManager": "bun@1.2.13",

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -453,9 +453,15 @@ class ApiService {
     }
   }
 
-  async preflightDeployment(nodeId: string): Promise<ApiResponse<NodePreflightResult>> {
+  async preflightDeployment(
+    nodeId: string,
+    component: DeployComponent,
+    operation: DeployOperation,
+  ): Promise<ApiResponse<NodePreflightResult>> {
     try {
-      return await apiClient.post(`api/cluster/nodes/${encodeURIComponent(nodeId)}/preflight`).json<ApiResponse<NodePreflightResult>>();
+      return await apiClient.post('api/deployments/preflight', {
+        json: { nodeId, component, operation },
+      }).json<ApiResponse<NodePreflightResult>>();
     } catch (error) { return this.handleError(error); }
   }
 

--- a/packages/frontend/src/pages/deploy.tsx
+++ b/packages/frontend/src/pages/deploy.tsx
@@ -165,7 +165,7 @@ export default function DeployPage() {
     setPreflighting(true)
     setError(null)
     try {
-      const response = await apiService.preflightDeployment(selectedNode)
+      const response = await apiService.preflightDeployment(selectedNode, component, operation)
       if (!response.success) throw new Error(errorMessage(response.error, 'SSH 预检失败'))
       const failed = response.data?.checks.filter(check => !check.ok) ?? []
       // 预检结论必须成为创建任务的 gate；本机节点由后端改为直接执行检查。
@@ -176,7 +176,7 @@ export default function DeployPage() {
       const message = caught instanceof Error ? caught.message : 'SSH 预检失败'
       setError(message)
     } finally { setPreflighting(false) }
-  }, [node?.nodeId, selectedNode])
+  }, [component, node?.nodeId, operation, selectedNode])
 
   const blocking = blockedNodes[selectedNode] ?? []
 
@@ -235,7 +235,8 @@ export default function DeployPage() {
     await refresh()
   }, [node?.name, refresh, selectedNode])
 
-  const installer = `curl -fsSL https://github.com/imal1/miobridge/releases/latest/download/install-agent.sh -o /tmp/install-agent.sh\nsudo sh /tmp/install-agent.sh --config /tmp/miobridge-agent.yaml`
+  const sshTarget = `${node?.sshUser || '<ssh-user>'}@${node?.host || '<child-host>'}`
+  const installer = `curl -fsSL https://github.com/imal1/miobridge/releases/latest/download/install-agent.sh -o /tmp/install-agent.sh\nsh /tmp/install-agent.sh --config /tmp/miobridge-agent.yaml`
 
   return (
     <SignalPage crumb="Deployment control plane" title="部署中心" description="每次只处理一个节点和一个组件；安装态变更、运行态维护和监控状态彼此分离。" status={`${activeTasks.length} 个活动任务 · ${taskList.filter(item => item.status === 'error').length} 个失败任务`} maxWidth="narrow" actions={<Button variant="outline" onClick={refresh}><Icon icon="ph:arrow-clockwise-light" />刷新状态</Button>}>
@@ -302,7 +303,7 @@ export default function DeployPage() {
       </Card>
 
       <Dialog open={manualOpen} onOpenChange={setManualOpen}>
-        <DialogContent className="max-w-2xl"><DialogHeader><DialogTitle>手动 Shell 部署 Agent</DialogTitle><DialogDescription>适用于无法由控制面直连 SSH 的子节点。它只安装 Agent，不安装 CLI、Dashboard、Bun、mihomo 或协议核心。</DialogDescription></DialogHeader><div className="space-y-4 py-2"><div className="grid gap-2 sm:grid-cols-3"><div className="rounded-2xl bg-[var(--surface-container)] p-3"><p className="text-xs text-muted-foreground">节点 ID</p><p className="break-all font-medium">{selectedNode}</p></div><div className="rounded-2xl bg-[var(--surface-container)] p-3"><p className="text-xs text-muted-foreground">节点名称</p><p className="font-medium">{node?.name || '—'}</p></div><div className="rounded-2xl bg-[var(--surface-container)] p-3"><p className="text-xs text-muted-foreground">Agent 端口</p><p className="font-medium">{node?.agent?.port || 3001}</p></div></div><ol className="list-decimal space-y-2 pl-5 text-sm"><li>下载下方 Agent 配置，并传到子节点的 <code>/tmp/miobridge-agent.yaml</code>。</li><li>在子节点下载校验过的安装器并执行。</li><li>返回本页刷新状态，立即检查 Agent 健康和心跳。</li></ol><pre className="overflow-x-auto rounded-2xl bg-[var(--surface-container-high)] p-4 text-xs leading-6">scp agent.yaml root@child:/tmp/miobridge-agent.yaml{`\n\n`}{installer}</pre></div><DialogFooter><Button asChild variant="outline"><a href={apiService.manualAgentConfigUrl(selectedNode)}><Icon icon="ph:download-simple-light" />下载 Agent 配置</a></Button><Button variant="outline" onClick={async () => { await navigator.clipboard.writeText(installer); toast.success('已复制安装命令') }}><Icon icon="ph:copy-light" />复制安装命令</Button><Button onClick={() => { setManualOpen(false); completeManual().catch(() => {}) }}>完成并检查健康</Button></DialogFooter></DialogContent>
+        <DialogContent className="max-w-2xl"><DialogHeader><DialogTitle>手动 Shell 部署 Agent</DialogTitle><DialogDescription>适用于无法由控制面直连 SSH 的子节点。它只安装 Agent，不安装 CLI、Dashboard、Bun、mihomo 或协议核心。</DialogDescription></DialogHeader><div className="space-y-4 py-2"><div className="grid gap-2 sm:grid-cols-3"><div className="rounded-2xl bg-[var(--surface-container)] p-3"><p className="text-xs text-muted-foreground">节点 ID</p><p className="break-all font-medium">{selectedNode}</p></div><div className="rounded-2xl bg-[var(--surface-container)] p-3"><p className="text-xs text-muted-foreground">节点名称</p><p className="font-medium">{node?.name || '—'}</p></div><div className="rounded-2xl bg-[var(--surface-container)] p-3"><p className="text-xs text-muted-foreground">Agent 端口</p><p className="font-medium">{node?.agent?.port || 3001}</p></div></div><ol className="list-decimal space-y-2 pl-5 text-sm"><li>下载下方 Agent 配置，并传到子节点的 <code>/tmp/miobridge-agent.yaml</code>。</li><li>在子节点下载校验过的安装器并执行。</li><li>返回本页刷新状态，立即检查 Agent 健康和心跳。</li></ol><pre className="overflow-x-auto rounded-2xl bg-[var(--surface-container-high)] p-4 text-xs leading-6">scp agent.yaml {sshTarget}:/tmp/miobridge-agent.yaml{`\n\n`}{installer}</pre></div><DialogFooter><Button asChild variant="outline"><a href={apiService.manualAgentConfigUrl(selectedNode)}><Icon icon="ph:download-simple-light" />下载 Agent 配置</a></Button><Button variant="outline" onClick={async () => { await navigator.clipboard.writeText(installer); toast.success('已复制安装命令') }}><Icon icon="ph:copy-light" />复制安装命令</Button><Button onClick={() => { setManualOpen(false); completeManual().catch(() => {}) }}>完成并检查健康</Button></DialogFooter></DialogContent>
       </Dialog>
     </SignalPage>
   )

--- a/scripts/install-agent.sh
+++ b/scripts/install-agent.sh
@@ -4,9 +4,9 @@ set -eu
 REPOSITORY="${MIOBRIDGE_REPOSITORY:-imal1/miobridge}"
 VERSION="${MIOBRIDGE_VERSION:-}"
 BASE_URL="${MIOBRIDGE_RELEASE_BASE_URL:-}"
-INSTALL_DIR="${MIOBRIDGE_AGENT_INSTALL_DIR:-/usr/local/bin}"
-CONFIG_DIR="${MIOBRIDGE_AGENT_CONFIG_DIR:-/etc/miobridge-agent}"
-UNIT_PATH="${MIOBRIDGE_AGENT_UNIT_PATH:-/etc/systemd/system/miobridge-agent.service}"
+INSTALL_DIR="${MIOBRIDGE_AGENT_INSTALL_DIR:-$HOME/.local/bin}"
+CONFIG_DIR="${MIOBRIDGE_AGENT_CONFIG_DIR:-$HOME/.config/miobridge-agent}"
+UNIT_PATH="${MIOBRIDGE_AGENT_UNIT_PATH:-${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user/miobridge-agent.service}"
 SYSTEMCTL="${MIOBRIDGE_AGENT_SYSTEMCTL:-systemctl}"
 CONFIG_SOURCE=""
 NODE_ID=""
@@ -31,8 +31,9 @@ Independent configuration mode:
                    [--kernel TYPE:CONFIG_PATH]... [--port PORT]
 
 The installer downloads a checksum-covered Agent binary, validates the
-configuration, installs a systemd unit, restarts the Agent, and verifies /health.
+configuration, installs a user systemd unit, restarts the Agent, and verifies /health.
 It never installs MioBridge CLI, Dashboard, Bun, mihomo, or protocol kernels.
+It runs entirely as the current user and does not require sudo.
 EOF
 }
 
@@ -71,14 +72,18 @@ case "$(uname -m)" in
   *) echo "unsupported Linux architecture: $(uname -m)" >&2; exit 1 ;;
 esac
 
-if [ "$(id -u)" -ne 0 ] && [ "${MIOBRIDGE_AGENT_ALLOW_NON_ROOT:-0}" != 1 ]; then
-  echo "install-agent.sh must run as root; use sudo sh install-agent.sh ..." >&2
-  exit 1
-fi
-
 for command in "$SYSTEMCTL" gzip awk sed mktemp mv cp chmod mkdir rm dirname head id cat sleep; do
   command -v "$command" >/dev/null 2>&1 || { echo "required command not found: $command" >&2; exit 1; }
 done
+
+systemctl_user() {
+  XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}" "$SYSTEMCTL" --user "$@"
+}
+
+if ! systemctl_user show-environment >/dev/null 2>&1; then
+  echo "user systemd is unavailable; log in as the target user or enable lingering for that account" >&2
+  exit 1
+fi
 
 download() {
   if command -v curl >/dev/null 2>&1; then curl -fL --retry 3 -o "$2" "$1"
@@ -128,18 +133,18 @@ had_unit=0
 
 rollback() {
   [ "$MUTATED" -eq 1 ] || return 0
-  "$SYSTEMCTL" stop miobridge-agent >/dev/null 2>&1 || true
+  systemctl_user stop miobridge-agent >/dev/null 2>&1 || true
   rm -f "$binary" "$config_candidate" "$unit_candidate"
   [ "$REPLACE_CONFIG" -eq 0 ] || rm -f "$config"
   rm -f "$UNIT_PATH"
   [ ! -e "$binary_backup" ] || mv "$binary_backup" "$binary"
   [ ! -e "$config_backup" ] || mv "$config_backup" "$config"
   [ ! -e "$unit_backup" ] || mv "$unit_backup" "$UNIT_PATH"
-  "$SYSTEMCTL" daemon-reload >/dev/null 2>&1 || true
+  systemctl_user daemon-reload >/dev/null 2>&1 || true
   if [ "$had_unit" -eq 1 ] && [ "$old_active" -eq 1 ]; then
-    "$SYSTEMCTL" restart miobridge-agent >/dev/null 2>&1 || true
+    systemctl_user restart miobridge-agent >/dev/null 2>&1 || true
   elif [ "$had_unit" -eq 0 ]; then
-    "$SYSTEMCTL" disable miobridge-agent >/dev/null 2>&1 || true
+    systemctl_user disable miobridge-agent >/dev/null 2>&1 || true
   fi
   MUTATED=0
 }
@@ -206,7 +211,7 @@ elif [ "$manual_config" -eq 1 ]; then
         printf '    configPath: "%s"\n' "$(yaml_quote "$kernel_path")"
       done
     fi
-    printf 'mihomo:\n  path: "/usr/local/bin/mihomo"\n'
+    printf 'mihomo:\n  path: "mihomo"\n'
     printf 'port: %s\n' "$PORT"
   } > "$tmp/agent.yaml"
   REPLACE_CONFIG=1
@@ -228,6 +233,7 @@ chmod 0755 "$binary_candidate"
 chmod 0600 "$config_candidate"
 escaped_binary=$(yaml_quote "$binary")
 escaped_config=$(yaml_quote "$config")
+escaped_config_dir=$(yaml_quote "$CONFIG_DIR")
 cat > "$unit_candidate" <<EOF
 [Unit]
 Description=MioBridge Agent
@@ -237,15 +243,19 @@ Wants=network-online.target
 [Service]
 Type=simple
 ExecStart="$escaped_binary" --config "$escaped_config"
+WorkingDirectory="$escaped_config_dir"
+Environment="PATH=%h/.config/miobridge/bin:%h/.local/bin:/usr/local/bin:/usr/bin:/bin"
 Restart=always
 RestartSec=5
+NoNewPrivileges=true
+PrivateTmp=true
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
 EOF
 chmod 0644 "$unit_candidate"
 
-"$SYSTEMCTL" is-active --quiet miobridge-agent >/dev/null 2>&1 && old_active=1 || true
+systemctl_user is-active --quiet miobridge-agent >/dev/null 2>&1 && old_active=1 || true
 [ ! -e "$binary" ] || had_binary=1
 [ ! -e "$config" ] || had_config=1
 [ ! -e "$UNIT_PATH" ] || had_unit=1
@@ -270,10 +280,10 @@ if ! replace_files; then
   exit 1
 fi
 
-if ! "$SYSTEMCTL" daemon-reload \
-  || ! "$SYSTEMCTL" enable miobridge-agent \
-  || ! "$SYSTEMCTL" restart miobridge-agent \
-  || ! "$SYSTEMCTL" is-active --quiet miobridge-agent; then
+if ! systemctl_user daemon-reload \
+  || ! systemctl_user enable miobridge-agent \
+  || ! systemctl_user restart miobridge-agent \
+  || ! systemctl_user is-active --quiet miobridge-agent; then
   rollback
   echo "Agent systemd activation failed; previous files restored" >&2
   exit 1
@@ -301,4 +311,4 @@ rm -f "$binary_backup" "$config_backup" "$unit_backup" "$config_candidate"
 MUTATED=0
 echo "MioBridge Agent $VERSION installed at $binary"
 echo "Agent config: $config"
-echo "systemd service: miobridge-agent (active)"
+echo "user systemd service: miobridge-agent (active)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -164,14 +164,7 @@ if [ "$RUN_SETUP" -eq 1 ] && [ "$LOCAL_NODE" -eq 1 ]; then
   fi
   [ "$actual_agent_installer" = "$expected_agent_installer" ] || { echo "checksum verification failed for install-agent.sh" >&2; exit 1; }
   chmod 0600 "$tmp/local-agent.yaml"
-  if [ "$(id -u)" -eq 0 ]; then
-    sh "$tmp/install-agent.sh" --config "$tmp/local-agent.yaml" --version "$VERSION" --base-url "$BASE_URL"
-  elif command -v sudo >/dev/null 2>&1; then
-    sudo sh "$tmp/install-agent.sh" --config "$tmp/local-agent.yaml" --version "$VERSION" --base-url "$BASE_URL"
-  else
-    echo "sudo is required to install the local-node Agent" >&2
-    exit 1
-  fi
+  sh "$tmp/install-agent.sh" --config "$tmp/local-agent.yaml" --version "$VERSION" --base-url "$BASE_URL"
 fi
 
 case ":${PATH:-}:" in

--- a/scripts/package-cli-release.sh
+++ b/scripts/package-cli-release.sh
@@ -8,6 +8,7 @@ BUN_CMD="${MIOBRIDGE_BUN_CMD:-bun}"
 DASHBOARD_PROVIDER_DIR="${MIOBRIDGE_DASHBOARD_PROVIDER_DIR:-}"
 GENERATED_DASHBOARD_ROOT=""
 AGENT_INSTALLER="${MIOBRIDGE_AGENT_INSTALLER:-$ROOT_DIR/scripts/install-agent.sh}"
+CLI_INSTALLER="${MIOBRIDGE_CLI_INSTALLER:-$ROOT_DIR/scripts/install.sh}"
 
 cleanup() {
   [[ -z "$GENERATED_DASHBOARD_ROOT" ]] || rm -rf "$GENERATED_DASHBOARD_ROOT"
@@ -32,6 +33,8 @@ elif [[ -f "$ROOT_DIR/agent/src/server.ts" ]]; then
   echo "Agent installer not found: $AGENT_INSTALLER" >&2
   exit 1
 fi
+[[ -f "$CLI_INSTALLER" ]] || { echo "CLI installer not found: $CLI_INSTALLER" >&2; exit 1; }
+sh -n "$CLI_INSTALLER"
 
 build_core() {
   # CLI source imports the public compiled core package. Rebuild it here so a
@@ -65,6 +68,7 @@ mkdir -p "$OUTPUT_DIR"
 rm -f \
   "$OUTPUT_DIR"/miobridge-"$VERSION"-linux-*.tar.gz \
   "$OUTPUT_DIR"/miobridge-agent-"$VERSION"-linux-*.gz \
+  "$OUTPUT_DIR/install.sh" \
   "$OUTPUT_DIR/install-agent.sh" \
   "$OUTPUT_DIR/SHA256SUMS"
 
@@ -121,6 +125,9 @@ build_agent() {
 build_agent x64 bun-linux-x64 "${MIOBRIDGE_AGENT_BINARY_X64:-}"
 build_agent arm64 bun-linux-arm64 "${MIOBRIDGE_AGENT_BINARY_ARM64:-}"
 
+cp "$CLI_INSTALLER" "$OUTPUT_DIR/install.sh"
+chmod 0755 "$OUTPUT_DIR/install.sh"
+
 if [[ -f "$AGENT_INSTALLER" ]]; then
   cp "$AGENT_INSTALLER" "$OUTPUT_DIR/install-agent.sh"
   chmod 0755 "$OUTPUT_DIR/install-agent.sh"
@@ -132,6 +139,7 @@ fi
     miobridge-"$VERSION"-linux-*.tar.gz
     miobridge-agent-"$VERSION"-linux-*.gz
   )
+  checksum_files+=(install.sh)
   [[ ! -f install-agent.sh ]] || checksum_files+=(install-agent.sh)
   LC_ALL=C shasum -a 256 "${checksum_files[@]}" > SHA256SUMS
 )


### PR DESCRIPTION
## What changed

- release MioBridge 1.2.3
- deploy Agent and mihomo entirely in current-user directories with user systemd
- keep Agent deployment independent from sing-box, Xray, and V2Ray installation
- run installed 233boy wrappers directly, with sudo fallback only for explicit permission failures
- remove Dashboard NoNewPrivileges so a genuinely required fallback is possible
- publish both install.sh and install-agent.sh as checksummed Release assets

## Why

Agent deployment previously called kernel installation paths and deployment maintenance unconditionally entered sudo. Under a Dashboard service with NoNewPrivileges this produced the reported sudo failure, even though 233boy wrappers were already globally executable.

## Impact

Deploying Agent no longer installs sing-box or another kernel. Routine Agent, mihomo, and compatible 233boy lifecycle operations do not require sudo. Existing legacy system-level Agent files require a one-time administrator cleanup before migrating.

## Validation

- core typecheck + 47 tests
- CLI typecheck + 158 tests
- Agent typecheck + 56 tests
- frontend typecheck, lint + 54 tests
- shell syntax checks
- full 1.2.3 release packaging
- SHA256 verification for both CLI archives, both Agent binaries, install.sh, and install-agent.sh
- packaged x64 CLI and Agent report 1.2.3