### PR TITLE
Fix subscription aggregation across all configs

### DIFF
--- a/.Codex/memory/bug-fixes.md
+++ b/.Codex/memory/bug-fixes.md
@@ -7,6 +7,12 @@ metadata:
 
 # Bug Fixes
 
+- 2026-07-20: Subscription aggregation expands every managed node, kernel,
+  config file, and configured client (including structured Hysteria2/TUIC/
+  Shadowsocks fallbacks and `hy2://`), and repairs empty legacy local-Agent
+  kernel lists before export. Clash conversion rejects partial node loss, allows
+  enough time for first-run validation, and emits the full DNS/group template
+  without replacing the existing routing rules.
 - 2026-07-19: Protocol-kernel install and maintenance are direct-only: upstream
   233boy installers and global wrappers run without MioBridge-generated sudo or
   privilege retries. Upgrade also rewrites the managed Dashboard user unit so

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miobridge-agent",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/agent/src/__tests__/handlers.test.ts
+++ b/agent/src/__tests__/handlers.test.ts
@@ -29,6 +29,15 @@ function fixture(contents: unknown, raw = false): string {
   return file;
 }
 
+function fixtureDirectory(files: Record<string, unknown>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'miobridge-handler-configs-test-'));
+  TEMP_DIRS.push(dir);
+  for (const [name, contents] of Object.entries(files)) {
+    fs.writeFileSync(path.join(dir, name), JSON.stringify(contents));
+  }
+  return dir;
+}
+
 function isolatedBinDir(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'miobridge-handler-bin-test-'));
   TEMP_DIRS.push(dir);
@@ -239,6 +248,53 @@ describe('handleStatus', () => {
 });
 
 describe('handleUrls', () => {
+  it('expands every configured core, every config file, and every client', async () => {
+    isolatedBinDir();
+    const singBoxConfigs = fixtureDirectory({
+      '01-hysteria2.json': { inbounds: [{ type: 'hysteria2', tag: 'hy2', listen_port: 2443, users: [{ password: 'hy-one' }, { password: 'hy-two' }], tls: { server_name: 'hy.example' } }] },
+      '02-trojan.json': { inbounds: [{ type: 'trojan', tag: 'trojan', listen_port: 3443, users: [{ password: 'trojan-one' }] }] },
+      'ignored.txt': { inbounds: [] },
+    });
+    const xray = fixture({ inbounds: [{
+      protocol: 'vless', tag: 'xray', port: 4443,
+      settings: { clients: [{ id: 'xray-one' }, { id: 'xray-two' }] },
+    }, {
+      protocol: 'shadowsocks', tag: 'xray-ss', port: 4444,
+      settings: { method: 'aes-128-gcm', password: 'xray-ss-password', network: 'tcp,udp' },
+    }] });
+    const v2ray = fixture({ inbounds: [{
+      protocol: 'trojan', tag: 'v2ray', port: 5443,
+      settings: { clients: [{ password: 'v2ray-one' }, { password: 'v2ray-two' }] },
+    }] });
+    const config: AgentConfig = {
+      ...MOCK_CONFIG,
+      node: { ...MOCK_CONFIG.node, secret: '' },
+      kernels: [
+        { type: 'sing-box', configPath: singBoxConfigs },
+        { type: 'xray', configPath: xray },
+        { type: 'v2ray', configPath: v2ray },
+      ],
+    };
+
+    const body = await (handleUrls(mockReq({ headers: { host: 'all.example' } }), config)).json();
+
+    expect(body.data.sources).toHaveLength(8);
+    expect(body.data.sources.filter((item: any) => item.kernel === 'sing-box')).toHaveLength(3);
+    expect(body.data.sources.filter((item: any) => item.kernel === 'xray')).toHaveLength(3);
+    expect(body.data.sources.filter((item: any) => item.kernel === 'v2ray')).toHaveLength(2);
+    expect(body.data.kernels.find((item: any) => item.type === 'sing-box')).toMatchObject({
+      accessible: true,
+      nodesCount: 3,
+      configPaths: [path.join(singBoxConfigs, '01-hysteria2.json'), path.join(singBoxConfigs, '02-trojan.json')],
+    });
+    expect(body.data.sources.map((item: any) => item.url)).toEqual(expect.arrayContaining([
+      expect.stringContaining('hysteria2://hy-one@all.example:2443'),
+      expect.stringContaining('hysteria2://hy-two@all.example:2443'),
+      expect.stringContaining('trojan://trojan-one@all.example:3443'),
+      expect.stringContaining('ss://'),
+    ]));
+  });
+
   it('returns structured sources for all kernels in stable order and removes exact duplicates', async () => {
     const config: AgentConfig = {
       ...MOCK_CONFIG,
@@ -304,7 +360,7 @@ describe('handleHealth', () => {
     const body = await res.json();
     expect(body.uptime).toBeDefined();
     expect(body.memory).toBeDefined();
-    expect(body.version).toBe('1.2.4');
+    expect(body.version).toBe('1.2.5');
   });
 });
 

--- a/agent/src/handlers/urls.ts
+++ b/agent/src/handlers/urls.ts
@@ -86,7 +86,20 @@ function findKernelBinary(type: KernelType): string | undefined {
 
 export function discoverKernelConfigFiles(kernel: AgentKernelConfig): string[] {
   const files = new Set<string>();
-  if (kernel.configPath) files.add(kernel.configPath);
+
+  const addPath = (candidate: string) => {
+    if (!fs.existsSync(candidate)) return;
+    const stat = fs.statSync(candidate);
+    if (stat.isFile()) {
+      if (candidate.endsWith('.json')) files.add(candidate);
+      return;
+    }
+    if (!stat.isDirectory()) return;
+    for (const name of fs.readdirSync(candidate).sort()) {
+      const file = path.join(candidate, name);
+      if (name.endsWith('.json') && fs.statSync(file).isFile()) files.add(file);
+    }
+  };
 
   const pathGroups = kernel.type === 'xray'
     ? { files: XRAY_CONFIG_PATHS, dirs: XRAY_CONF_DIRS }
@@ -94,15 +107,14 @@ export function discoverKernelConfigFiles(kernel: AgentKernelConfig): string[] {
       ? { files: V2RAY_CONFIG_PATHS, dirs: V2RAY_CONF_DIRS }
       : { files: SING_BOX_CONFIG_PATHS, dirs: SING_BOX_CONF_DIRS };
 
-  for (const file of pathGroups.files) files.add(file);
-  for (const dir of pathGroups.dirs) {
-      if (!fs.existsSync(dir)) continue;
-      for (const name of fs.readdirSync(dir)) {
-        if (name.endsWith('.json')) files.add(path.join(dir, name));
-      }
+  if (kernel.configPath && !pathGroups.files.includes(kernel.configPath)) {
+    addPath(kernel.configPath);
+  } else {
+    for (const file of pathGroups.files) addPath(file);
+    for (const dir of pathGroups.dirs) addPath(dir);
   }
 
-  return Array.from(files).filter(file => fs.existsSync(file));
+  return Array.from(files);
 }
 
 function requestHost(req: IncomingRequest): string {
@@ -121,81 +133,129 @@ function publicKeyFromOutbounds(outbounds: any[] | undefined): string {
   return '';
 }
 
-function inboundToUrl(inbound: any, host: string, publicKey: string): string | null {
+function sourceName(tag: string, index: number, count: number): string {
+  return encodeURIComponent(count > 1 ? `${tag}-${index + 1}` : tag);
+}
+
+function inboundToUrls(inbound: any, host: string, publicKey: string): string[] {
   const type = inbound?.type;
   const port = inbound?.listen_port;
   const tag = inbound?.tag || type;
-  if (!host || !port) return null;
+  if (!host || !port) return [];
+  const users = Array.isArray(inbound.users) ? inbound.users : [];
 
   if (type === 'vless') {
-    const user = inbound.users?.[0];
-    const uuid = user?.uuid;
-    if (!uuid) return null;
-
-    const params = new URLSearchParams();
-    params.set('type', 'tcp');
-    if (inbound.tls?.enabled) {
-      params.set('security', inbound.tls.reality?.enabled ? 'reality' : 'tls');
-      params.set('sni', inbound.tls.server_name || inbound.tls.reality?.handshake?.server || host);
-    }
-    if (user.flow) params.set('flow', user.flow);
-    if (publicKey) params.set('pbk', publicKey);
-    const shortId = inbound.tls?.reality?.short_id?.[0];
-    if (shortId) params.set('sid', shortId);
-    return `vless://${uuid}@${host}:${port}?${params.toString()}#${encodeURIComponent(tag)}`;
+    return users.flatMap((user: any, index: number) => {
+      const uuid = user?.uuid;
+      if (!uuid) return [];
+      const params = new URLSearchParams();
+      params.set('type', 'tcp');
+      if (inbound.tls?.enabled) {
+        params.set('security', inbound.tls.reality?.enabled ? 'reality' : 'tls');
+        params.set('sni', inbound.tls.server_name || inbound.tls.reality?.handshake?.server || host);
+      }
+      if (user.flow) params.set('flow', user.flow);
+      if (publicKey) params.set('pbk', publicKey);
+      const shortId = inbound.tls?.reality?.short_id?.[0];
+      if (shortId) params.set('sid', shortId);
+      return [`vless://${encodeURIComponent(uuid)}@${host}:${port}?${params.toString()}#${sourceName(tag, index, users.length)}`];
+    });
   }
 
   if (type === 'trojan') {
-    const password = inbound.users?.[0]?.password;
-    if (!password) return null;
     const params = new URLSearchParams();
     if (inbound.tls?.enabled) {
       params.set('security', 'tls');
       params.set('sni', inbound.tls.server_name || host);
     }
-    return `trojan://${password}@${host}:${port}?${params.toString()}#${encodeURIComponent(tag)}`;
+    return users.flatMap((user: any, index: number) => user?.password
+      ? [`trojan://${encodeURIComponent(user.password)}@${host}:${port}?${params.toString()}#${sourceName(tag, index, users.length)}`]
+      : []);
   }
 
-  return null;
+  if (type === 'hysteria2') {
+    const params = new URLSearchParams();
+    params.set('sni', inbound.tls?.server_name || host);
+    if (inbound.tls?.insecure) params.set('insecure', '1');
+    if (inbound.obfs?.type) params.set('obfs', inbound.obfs.type);
+    if (inbound.obfs?.password) params.set('obfs-password', inbound.obfs.password);
+    return users.flatMap((user: any, index: number) => user?.password
+      ? [`hysteria2://${encodeURIComponent(user.password)}@${host}:${port}?${params.toString()}#${sourceName(tag, index, users.length)}`]
+      : []);
+  }
+
+  if (type === 'tuic') {
+    return users.flatMap((user: any, index: number) => {
+      if (!user?.uuid || !user?.password) return [];
+      const params = new URLSearchParams();
+      params.set('sni', inbound.tls?.server_name || host);
+      if (inbound.tls?.insecure) params.set('allow_insecure', '1');
+      return [`tuic://${encodeURIComponent(user.uuid)}:${encodeURIComponent(user.password)}@${host}:${port}?${params.toString()}#${sourceName(tag, index, users.length)}`];
+    });
+  }
+
+  if (type === 'shadowsocks') {
+    const method = inbound.method;
+    const credentials = [
+      ...(inbound.password ? [{ password: inbound.password }] : []),
+      ...users.filter((user: any) => user?.password),
+    ];
+    if (!method) return [];
+    return credentials.map((user: any, index: number) => {
+      const userInfo = Buffer.from(`${method}:${user.password}`).toString('base64url');
+      return `ss://${userInfo}@${host}:${port}#${sourceName(tag, index, credentials.length)}`;
+    });
+  }
+
+  return [];
 }
 
-function xrayInboundToUrl(inbound: any, host: string): string | null {
+function xrayInboundToUrls(inbound: any, host: string): string[] {
   const protocol = inbound?.protocol;
   const port = inbound?.port;
   const tag = inbound?.tag || protocol;
-  const client = inbound?.settings?.clients?.[0];
-  if (!host || !port || !client) return null;
+  const clients = Array.isArray(inbound?.settings?.clients) ? inbound.settings.clients : [];
+  if (!host || !port) return [];
+
+  if (protocol === 'shadowsocks') {
+    const method = inbound?.settings?.method;
+    const password = inbound?.settings?.password;
+    if (!method || !password) return [];
+    const userInfo = Buffer.from(`${method}:${password}`).toString('base64url');
+    return [`ss://${userInfo}@${host}:${port}#${encodeURIComponent(tag)}`];
+  }
+
+  if (clients.length === 0) return [];
 
   const stream = inbound.streamSettings || {};
   if (protocol === 'vless') {
-    const params = new URLSearchParams();
-    params.set('type', stream.network || 'tcp');
-    if (stream.security && stream.security !== 'none') params.set('security', stream.security);
-    const sni = stream.tlsSettings?.serverName || stream.realitySettings?.serverName || host;
-    params.set('sni', sni);
-    if (client.flow) params.set('flow', client.flow);
-    if (stream.realitySettings?.publicKey) params.set('pbk', stream.realitySettings.publicKey);
-    if (stream.realitySettings?.shortId) params.set('sid', stream.realitySettings.shortId);
-    if (stream.wsSettings?.path) params.set('path', stream.wsSettings.path);
-    return `vless://${client.id}@${host}:${port}?${params.toString()}#${encodeURIComponent(tag)}`;
+    return clients.flatMap((client: any, index: number) => {
+      if (!client?.id) return [];
+      const params = new URLSearchParams();
+      params.set('type', stream.network || 'tcp');
+      if (stream.security && stream.security !== 'none') params.set('security', stream.security);
+      const sni = stream.tlsSettings?.serverName || stream.realitySettings?.serverName || host;
+      params.set('sni', sni);
+      if (client.flow) params.set('flow', client.flow);
+      if (stream.realitySettings?.publicKey) params.set('pbk', stream.realitySettings.publicKey);
+      if (stream.realitySettings?.shortId) params.set('sid', stream.realitySettings.shortId);
+      if (stream.wsSettings?.path) params.set('path', stream.wsSettings.path);
+      return [`vless://${encodeURIComponent(client.id)}@${host}:${port}?${params.toString()}#${sourceName(tag, index, clients.length)}`];
+    });
   }
 
   if (protocol === 'vmess') {
-    const vmess = {
-      v: '2',
-      ps: tag,
-      add: host,
-      port: String(port),
-      id: client.id,
-      aid: String(client.alterId || 0),
-      scy: client.security || 'auto',
-      net: stream.network || 'tcp',
-      type: 'none',
-      host: stream.wsSettings?.headers?.Host || '',
-      path: stream.wsSettings?.path || '/',
-      tls: stream.security === 'tls' ? 'tls' : '',
-    };
-    return `vmess://${Buffer.from(JSON.stringify(vmess)).toString('base64')}`;
+    return clients.flatMap((client: any, index: number) => {
+      if (!client?.id) return [];
+      const vmess = {
+        v: '2', ps: clients.length > 1 ? `${tag}-${index + 1}` : tag, add: host,
+        port: String(port), id: client.id, aid: String(client.alterId || 0),
+        scy: client.security || 'auto', net: stream.network || 'tcp', type: 'none',
+        host: stream.wsSettings?.headers?.Host || '', path: stream.wsSettings?.path || '/',
+        tls: stream.security === 'tls' ? 'tls' : '',
+      };
+      return [`vmess://${Buffer.from(JSON.stringify(vmess)).toString('base64')}`];
+    });
   }
 
   if (protocol === 'trojan') {
@@ -204,10 +264,12 @@ function xrayInboundToUrl(inbound: any, host: string): string | null {
     params.set('security', stream.security === 'reality' ? 'reality' : 'tls');
     params.set('sni', sni);
     if (stream.wsSettings?.path) params.set('path', stream.wsSettings.path);
-    return `trojan://${client.password}@${host}:${port}?${params.toString()}#${encodeURIComponent(tag)}`;
+    return clients.flatMap((client: any, index: number) => client?.password
+      ? [`trojan://${encodeURIComponent(client.password)}@${host}:${port}?${params.toString()}#${sourceName(tag, index, clients.length)}`]
+      : []);
   }
 
-  return null;
+  return [];
 }
 
 function urlsFromWrapper(executable: string, file: string): string[] {
@@ -242,10 +304,10 @@ function extractKernelNodeUrls(kernel: AgentKernelConfig, configPaths: string[],
       const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
       const publicKey = publicKeyFromOutbounds(parsed.outbounds);
       for (const inbound of parsed.inbounds || []) {
-        const url = kernel.type === 'sing-box'
-          ? inboundToUrl(inbound, host, publicKey)
-          : xrayInboundToUrl(inbound, host);
-        if (url) urls.push(url);
+        const inboundUrls = kernel.type === 'sing-box'
+          ? inboundToUrls(inbound, host, publicKey)
+          : xrayInboundToUrls(inbound, host);
+        urls.push(...inboundUrls);
       }
       readableFiles += 1;
     } catch (error) {

--- a/agent/src/version.ts
+++ b/agent/src/version.ts
@@ -1,1 +1,1 @@
-export const AGENT_VERSION = process.env.MIOBRIDGE_BUILD_VERSION ?? '1.2.4';
+export const AGENT_VERSION = process.env.MIOBRIDGE_BUILD_VERSION ?? '1.2.5';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miobridge",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "MioBridge — sing-box to Clash subscription converter powered by mihomo, supporting vless/vmess/trojan/hysteria2/tuic",
   "private": true,
   "packageManager": "bun@1.2.13",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miobridge/cli",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -8,7 +8,7 @@ import { formatLocalNodeConfiguration, type LocalNodeConfigurationService } from
 import { formatDashboardDaemonStatus, type DashboardDaemonAction } from './dashboard/commands.js';
 import type { DashboardDaemonStatus } from './dashboard/systemd.js';
 
-export const CLI_VERSION = process.env.MIOBRIDGE_BUILD_VERSION ?? '1.2.4';
+export const CLI_VERSION = process.env.MIOBRIDGE_BUILD_VERSION ?? '1.2.5';
 
 export interface CliCore {
   updateSubscription(): Promise<UpdateResult>;

--- a/packages/cli/src/nodes/localConfiguration.ts
+++ b/packages/cli/src/nodes/localConfiguration.ts
@@ -40,8 +40,9 @@ export class LocalNodeConfigurationService {
   }
 
   async agentConfig(): Promise<string> {
-    const node = (await this.repository.list({ enabledOnly: false })).find(item => item.id === LOCAL_NODE_ID);
+    let node = (await this.repository.list({ enabledOnly: false })).find(item => item.id === LOCAL_NODE_ID);
     if (!node) throw new Error('Local node is not configured');
+    if (node.kernels.length === 0) node = await this.repository.configureLocalNode(true) ?? node;
     return stringify({
       node: { id: node.id, name: node.name, secret: node.secret },
       kernels: node.kernels.map(kernel => ({

--- a/packages/cli/test/headless.test.ts
+++ b/packages/cli/test/headless.test.ts
@@ -64,7 +64,7 @@ describe('headless CLI composition', () => {
     });
     expect(result.code).toBe(0);
     expect(result.stderr).toBe('');
-    expect(JSON.parse(result.stdout)).toMatchObject({ version: '1.2.4', subscriptionExists: false });
+    expect(JSON.parse(result.stdout)).toMatchObject({ version: '1.2.5', subscriptionExists: false });
     expect(await readdir(cwd)).toEqual(['.keep']);
     await rm(sandbox, { recursive: true, force: true });
   });

--- a/packages/cli/test/local-node-configuration.test.ts
+++ b/packages/cli/test/local-node-configuration.test.ts
@@ -62,6 +62,21 @@ describe('local node configuration', () => {
     ]);
   });
 
+  it('repairs a legacy empty local profile before exporting Agent config', async () => {
+    const repository = new NodeRepository(memoryStore());
+    await repository.save([{
+      id: 'local', name: '本机节点', host: '127.0.0.1', secret: 'secret',
+      kernels: [], location: '本机', enabled: true,
+    }]);
+
+    const config = await new LocalNodeConfigurationService(repository, { confirm: async () => true }).agentConfig();
+
+    expect(config).toContain('type: sing-box');
+    expect(config).toContain('type: xray');
+    expect(config).toContain('type: v2ray');
+    expect((await repository.list())[0]?.kernels).toHaveLength(3);
+  });
+
   it('supports explicit disable without prompting and keeps child nodes', async () => {
     const repository = new NodeRepository(memoryStore());
     await repository.configureLocalNode(true);

--- a/packages/cli/test/release/release.test.ts
+++ b/packages/cli/test/release/release.test.ts
@@ -109,7 +109,7 @@ describe('CLI release distribution', () => {
       '',
     ].join('\n'));
     chmodSync(fakeBun, 0o755);
-    execFileSync('bash', [sandboxScript, '1.2.4'], {
+    execFileSync('bash', [sandboxScript, '1.2.5'], {
       env: { ...process.env, FAKE_BUN_LOG: log, MIOBRIDGE_BUN_CMD: fakeBun, MIOBRIDGE_RELEASE_DIR: release, MIOBRIDGE_DASHBOARD_PROVIDER_DIR: provider },
     });
     expect(readFileSync(log, 'utf8').trim().split('\n')).toEqual([

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miobridge/core",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/src/artifacts/artifactService.ts
+++ b/packages/core/src/artifacts/artifactService.ts
@@ -33,7 +33,7 @@ export interface ArtifactServiceOptions {
   readonly now?: () => Date;
 }
 
-const protocols = ['vless://', 'vmess://', 'ss://', 'ssr://', 'trojan://', 'hysteria2://', 'tuic://', 'wireguard://'] as const;
+const protocols = ['vless://', 'vmess://', 'ss://', 'ssr://', 'trojan://', 'hysteria2://', 'hy2://', 'tuic://', 'wireguard://'] as const;
 
 export class ArtifactService {
   private readonly now: () => Date;

--- a/packages/core/src/kernels/mihomoAdapter.ts
+++ b/packages/core/src/kernels/mihomoAdapter.ts
@@ -14,6 +14,15 @@ export interface MihomoAdapterOptions {
 }
 interface ProxyConfig { name: string; type: string; server: string; port: number; [key: string]: unknown }
 
+const DNS_CONFIG = {
+  enable: true,
+  listen: '0.0.0.0:53',
+  'default-nameserver': ['223.5.5.5', '119.29.29.29'],
+  'enhanced-mode': 'fake-ip',
+  'fake-ip-range': '198.18.0.1/16',
+  nameserver: ['https://doh.pub/dns-query', 'https://dns.alidns.com/dns-query'],
+} as const;
+
 const DEFAULT_RULES = [
   'DOMAIN-SUFFIX,local,DIRECT',
   'IP-CIDR,127.0.0.0/8,DIRECT,no-resolve',
@@ -91,14 +100,24 @@ export class MihomoAdapter {
     } catch (error) { this.options.logger.error('获取 mihomo 版本失败', { error: String(error) }); return null; }
   }
   async convertToClashByContent(content: string): Promise<string> {
-    const proxies = content.split('\n').map(line => line.trim()).filter(Boolean).map(line => this.parse(line)).filter((value): value is ProxyConfig => value !== null);
+    const lines = content.split('\n').map(line => line.trim()).filter(Boolean);
+    const parsed = lines.map(line => ({ line, proxy: this.parse(line) }));
+    const rejected = parsed.filter(item => item.proxy === null);
+    if (rejected.length > 0) {
+      const protocols = [...new Set(rejected.map(item => item.line.split('://')[0] || 'unknown'))];
+      throw new Error(`有 ${rejected.length}/${lines.length} 个代理节点无法转换（协议: ${protocols.join(', ')}）`);
+    }
+    const proxies = parsed.map(item => item.proxy).filter((value): value is ProxyConfig => value !== null);
     if (proxies.length === 0) throw new Error('未找到有效的代理节点');
     const names = proxies.map(proxy => proxy.name);
-   const yaml = YAML.stringify({ port: 7890, 'socks-port': 7891, 'allow-lan': false, mode: 'rule', 'log-level': 'info', 'external-controller': '127.0.0.1:9090', proxies, 'proxy-groups': [
+    const yaml = YAML.stringify({ port: 7890, 'socks-port': 7891, 'allow-lan': false, mode: 'rule', 'log-level': 'info', 'external-controller': '127.0.0.1:9090', dns: DNS_CONFIG, proxies, 'proxy-groups': [
+      { name: '🚀 节点选择', type: 'select', proxies: ['♻️ 自动选择', '🔯 故障转移', '🔮 负载均衡', '🎯 全球直连', ...names] },
       { name: '♻️ 自动选择', type: 'url-test', proxies: names, url: 'http://www.gstatic.com/generate_204', interval: 300 },
       { name: '🔯 故障转移', type: 'fallback', proxies: names, url: 'http://www.gstatic.com/generate_204', interval: 300 },
       { name: '🔮 负载均衡', type: 'load-balance', proxies: names, url: 'http://www.gstatic.com/generate_204', interval: 300 },
-  ], rules: DEFAULT_RULES }, { lineWidth: 0 });
+      { name: '🎯 全球直连', type: 'select', proxies: ['DIRECT'] },
+      { name: '🐟 漏网之鱼', type: 'select', proxies: ['🚀 节点选择', '🎯 全球直连', '♻️ 自动选择'] },
+    ], rules: DEFAULT_RULES }, { lineWidth: 0 });
     const output = `# Clash 配置文件\n# 由 miobridge 生成，mihomo 可用时自动验证\n# 生成时间: ${new Date().toISOString()}\n# 节点数量: ${proxies.length}\n\n${yaml}`;
     await this.validate(output);
     return output;
@@ -132,6 +151,16 @@ export class MihomoAdapter {
       else if (type === 'ss') { const [cipher, password] = Buffer.from(url.username, 'base64').toString().split(':'); Object.assign(proxy, { cipher, password }); }
       else Object.assign(proxy, { password: decodeURIComponent(url.username), ...(type === 'trojan' ? { network } : {}), 'skip-cert-verify': url.searchParams.get('insecure') === '1' });
       const sni = url.searchParams.get('sni'); if (sni) proxy[type === 'vless' ? 'servername' : 'sni'] = sni;
+      const alpn = url.searchParams.get('alpn'); if (alpn) proxy.alpn = alpn.split(',').filter(Boolean);
+      if (type === 'hysteria2') {
+        const obfs = url.searchParams.get('obfs'); if (obfs) proxy.obfs = obfs;
+        const obfsPassword = url.searchParams.get('obfs-password') || url.searchParams.get('obfs_password'); if (obfsPassword) proxy['obfs-password'] = obfsPassword;
+        const up = url.searchParams.get('up') || url.searchParams.get('upmbps'); if (up) proxy.up = up;
+        const down = url.searchParams.get('down') || url.searchParams.get('downmbps'); if (down) proxy.down = down;
+      }
+      if (type === 'tuic') {
+        const congestion = url.searchParams.get('congestion_control') || url.searchParams.get('congestion-controller'); if (congestion) proxy['congestion-controller'] = congestion;
+      }
       if (network === 'ws') proxy['ws-opts'] = { path: url.searchParams.get('path') || '/', ...(url.searchParams.get('host') ? { headers: { Host: url.searchParams.get('host')! } } : {}) };
       if (network === 'grpc') proxy['grpc-opts'] = { 'grpc-service-name': url.searchParams.get('serviceName') || url.searchParams.get('service_name') || '' };
       return proxy;
@@ -144,7 +173,7 @@ export class MihomoAdapter {
     const temp = join(configDir, 'temp-config.yaml');
     await this.options.fs.mkdir(configDir);
     await this.options.fs.writeFile(temp, config);
-    try { await this.options.process.run(executable, ['-d', this.options.runtimeDir, '-t', '-f', temp], this.processOptions(10000)); }
+    try { await this.options.process.run(executable, ['-d', this.options.runtimeDir, '-t', '-f', temp], this.processOptions(30_000)); }
     catch (error) { throw new Error(`配置验证失败: ${error instanceof Error ? error.message : String(error)}`); }
     finally { await this.options.fs.remove(temp); }
   }

--- a/packages/core/test/artifacts-core.test.ts
+++ b/packages/core/test/artifacts-core.test.ts
@@ -95,6 +95,23 @@ describe('ArtifactService', () => {
     }
     expect(await readFile(join(config.staticDir, 'clash.yaml'), 'utf8')).toContain('proxies:');
   });
+
+  it('keeps the hy2 alias when aggregating multiple local config outputs', async () => {
+    const { config } = await setup();
+    const hy2 = 'hy2://secret@hy.example:443#hy2';
+    const trojan = 'trojan://secret@trojan.example:443#trojan';
+    let clashInput = '';
+    const service = new ArtifactService({
+      config, logger,
+      local: { isAvailable: async () => true, extractNodeUrls: async () => [hy2, trojan] },
+      remote: { collectRemoteNodeSources: async () => ({ sources: [], errors: [] }) },
+      clash: { checkHealth: async () => true, convertToClashByContent: async content => { clashInput = content; return `proxies:\n${content}\n`; } },
+    });
+
+    expect((await service.updateSubscription()).nodesCount).toBe(2);
+    expect(clashInput.split('\n')).toHaveLength(2);
+    expect(clashInput).toContain('hy2://');
+  });
 });
 
 describe('MioBridgeCore', () => {

--- a/packages/core/test/kernels/adapters.test.ts
+++ b/packages/core/test/kernels/adapters.test.ts
@@ -127,6 +127,39 @@ describe('kernel adapters', () => {
     expect(output.rules).not.toContain('IP-CIDR,17.0.0.0/8,DIRECT');
   });
 
+  it('renders every input node into the complete Clash template without replacing routing rules', async () => {
+    const paths = createRuntimePaths({ env: { MIOBRIDGE_CONFIG_DIR: '/state', PATH: '' }, applicationRoot: '/app' });
+    const fs = new MemoryFs();
+    fs.files.set('/state/bin/mihomo', 'binary');
+    const process = new FakeProcess();
+    const adapter = new MihomoAdapter({ paths, process, fs, logger, runtimeDir: '/runtime' });
+    const output = YAML.parse(await adapter.convertToClashByContent([
+      'hysteria2://password@hy.example:443?sni=hy.example&alpn=h3#hy2',
+      'trojan://password@trojan.example:443?sni=trojan.example#trojan',
+    ].join('\n')));
+
+    expect(output.proxies).toHaveLength(2);
+    expect(output.dns).toMatchObject({ enable: true, 'enhanced-mode': 'fake-ip' });
+    expect(output['proxy-groups'].map((group: any) => group.name)).toEqual([
+      '🚀 节点选择', '♻️ 自动选择', '🔯 故障转移', '🔮 负载均衡', '🎯 全球直连', '🐟 漏网之鱼',
+    ]);
+    expect(output['proxy-groups'][0].proxies).toEqual(expect.arrayContaining(['hy2', 'trojan']));
+    expect(output.rules).toContain('DOMAIN-SUFFIX,openai.com,♻️ 自动选择');
+    expect(output.rules.at(-1)).toBe('MATCH,♻️ 自动选择');
+    expect(process.calls.at(-1)?.options.timeout).toBe(30_000);
+  });
+
+  it('rejects a partial conversion instead of publishing fewer proxies than the input', async () => {
+    const paths = createRuntimePaths({ env: { MIOBRIDGE_CONFIG_DIR: '/state', PATH: '' }, applicationRoot: '/app' });
+    const fs = new MemoryFs();
+    fs.files.set('/state/bin/mihomo', 'binary');
+    const adapter = new MihomoAdapter({ paths, process: new FakeProcess(), fs, logger, runtimeDir: '/runtime' });
+    await expect(adapter.convertToClashByContent([
+      'trojan://password@ok.example:443#ok',
+      'wireguard://unsupported@example:443#not-silently-dropped',
+    ].join('\n'))).rejects.toThrow('1/2 个代理节点无法转换');
+  });
+
   it('falls back to PATH discovery and reports mihomo availability', async () => {
     const paths = createRuntimePaths({ env: { MIOBRIDGE_CONFIG_DIR: '/state', PATH: '' } });
     const process = new FakeProcess('/usr/bin/mihomo');

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miobridge/e2e",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miobridge/frontend",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Dashboard for MioBridge \u2014 sing-box to Clash converter powered by mihomo",
   "private": true,
   "packageManager": "bun@1.2.13",


### PR DESCRIPTION
## What changed

- expand every managed node, kernel, JSON config file, inbound, and configured client
- add structured Hysteria2, TUIC, and Shadowsocks extraction plus `hy2://` aggregation
- repair legacy local Agent profiles with an empty kernel list before exporting Agent config
- reject partial Clash conversion instead of silently dropping proxies
- add DNS and the full selector/fallback/load-balance/direct/catch-all group template while preserving the existing routing rules
- extend Mihomo validation timeout for first-run GeoIP initialization
- bump the release version to 1.2.5

## Root cause

The fallback Agent parser only read the first user/client and did not support Hysteria2 or Shadowsocks. The affected server currently has one Hysteria2 and one Trojan config under sing-box plus one Shadowsocks config under Xray, but Agent 1.2.1 reported only Trojan. A legacy local Agent profile also contained `kernels: []`. Separately, Clash conversion could publish fewer proxies than its input or leave an older Clash artifact after a 10-second validation timeout.

## Validation

- Core unit tests: 50 passed
- Agent unit tests: 57 passed
- CLI unit/release-contract tests: 163 passed
- Agent and Core type checks passed
- Read-only inspection of the managed servers confirms the expected result is 4 proxies: local VLESS plus remote Hysteria2, Trojan, and Shadowsocks

No local Playwright or E2E suite was run.