### PR TITLE
Fix Agent installer systemd unit paths

### DIFF
--- a/.Codex/memory/bug-fixes.md
+++ b/.Codex/memory/bug-fixes.md
@@ -7,6 +7,9 @@ metadata:
 
 # Bug Fixes
 
+- 2026-07-20: Agent release installer writes unquoted systemd directive values;
+  quoted `WorkingDirectory=` values are interpreted literally and prevent service
+  activation, so the installer correctly rolls back instead of leaving an Agent down.
 - 2026-07-20: Subscription aggregation expands every managed node, kernel,
   config file, and configured client (including structured Hysteria2/TUIC/
   Shadowsocks fallbacks and `hy2://`), and repairs empty legacy local-Agent

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miobridge-agent",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/agent/src/__tests__/handlers.test.ts
+++ b/agent/src/__tests__/handlers.test.ts
@@ -360,7 +360,7 @@ describe('handleHealth', () => {
     const body = await res.json();
     expect(body.uptime).toBeDefined();
     expect(body.memory).toBeDefined();
-    expect(body.version).toBe('1.2.5');
+    expect(body.version).toBe('1.2.6');
   });
 });
 

--- a/agent/src/__tests__/installer.test.ts
+++ b/agent/src/__tests__/installer.test.ts
@@ -146,8 +146,11 @@ describe('install-agent.sh', () => {
       const binary = join(context.installDir, 'miobridge-agent');
       expect(output).toContain('MioBridge Agent 1.2.3 installed');
       expect(execFileSync(binary, ['--marker'], { encoding: 'utf8' }).trim()).toBe('initial');
-      expect(readFileSync(context.unitPath, 'utf8')).toContain(`ExecStart="${binary}" --config "${join(context.configDir, 'agent.yaml')}"`);
-      expect(readFileSync(context.unitPath, 'utf8')).toContain('WantedBy=default.target');
+      const unit = readFileSync(context.unitPath, 'utf8');
+      expect(unit).toContain(`ExecStart=${binary} --config ${join(context.configDir, 'agent.yaml')}`);
+      expect(unit).toContain(`WorkingDirectory=${context.configDir}`);
+      expect(unit).not.toContain('WorkingDirectory="');
+      expect(unit).toContain('WantedBy=default.target');
       expect(readFileSync(context.systemctlLog, 'utf8')).toContain('--user daemon-reload');
       expect(readFileSync(context.systemctlLog, 'utf8')).toContain('--user restart miobridge-agent');
     },

--- a/agent/src/version.ts
+++ b/agent/src/version.ts
@@ -1,1 +1,1 @@
-export const AGENT_VERSION = process.env.MIOBRIDGE_BUILD_VERSION ?? '1.2.5';
+export const AGENT_VERSION = process.env.MIOBRIDGE_BUILD_VERSION ?? '1.2.6';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miobridge",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "MioBridge — sing-box to Clash subscription converter powered by mihomo, supporting vless/vmess/trojan/hysteria2/tuic",
   "private": true,
   "packageManager": "bun@1.2.13",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miobridge/cli",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -8,7 +8,7 @@ import { formatLocalNodeConfiguration, type LocalNodeConfigurationService } from
 import { formatDashboardDaemonStatus, type DashboardDaemonAction } from './dashboard/commands.js';
 import type { DashboardDaemonStatus } from './dashboard/systemd.js';
 
-export const CLI_VERSION = process.env.MIOBRIDGE_BUILD_VERSION ?? '1.2.5';
+export const CLI_VERSION = process.env.MIOBRIDGE_BUILD_VERSION ?? '1.2.6';
 
 export interface CliCore {
   updateSubscription(): Promise<UpdateResult>;

--- a/packages/cli/test/headless.test.ts
+++ b/packages/cli/test/headless.test.ts
@@ -64,7 +64,7 @@ describe('headless CLI composition', () => {
     });
     expect(result.code).toBe(0);
     expect(result.stderr).toBe('');
-    expect(JSON.parse(result.stdout)).toMatchObject({ version: '1.2.5', subscriptionExists: false });
+    expect(JSON.parse(result.stdout)).toMatchObject({ version: '1.2.6', subscriptionExists: false });
     expect(await readdir(cwd)).toEqual(['.keep']);
     await rm(sandbox, { recursive: true, force: true });
   });

--- a/packages/cli/test/release/release.test.ts
+++ b/packages/cli/test/release/release.test.ts
@@ -109,7 +109,7 @@ describe('CLI release distribution', () => {
       '',
     ].join('\n'));
     chmodSync(fakeBun, 0o755);
-    execFileSync('bash', [sandboxScript, '1.2.5'], {
+    execFileSync('bash', [sandboxScript, '1.2.6'], {
       env: { ...process.env, FAKE_BUN_LOG: log, MIOBRIDGE_BUN_CMD: fakeBun, MIOBRIDGE_RELEASE_DIR: release, MIOBRIDGE_DASHBOARD_PROVIDER_DIR: provider },
     });
     expect(readFileSync(log, 'utf8').trim().split('\n')).toEqual([

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miobridge/core",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miobridge/e2e",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miobridge/frontend",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Dashboard for MioBridge \u2014 sing-box to Clash converter powered by mihomo",
   "private": true,
   "packageManager": "bun@1.2.13",

--- a/scripts/install-agent.sh
+++ b/scripts/install-agent.sh
@@ -242,9 +242,9 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart="$escaped_binary" --config "$escaped_config"
-WorkingDirectory="$escaped_config_dir"
-Environment="PATH=%h/.config/miobridge/bin:%h/.local/bin:/usr/local/bin:/usr/bin:/bin"
+ExecStart=$escaped_binary --config $escaped_config
+WorkingDirectory=$escaped_config_dir
+Environment=PATH=%h/.config/miobridge/bin:%h/.local/bin:/usr/local/bin:/usr/bin:/bin
 Restart=always
 RestartSec=5
 NoNewPrivileges=true


### PR DESCRIPTION
## What changed

- emit unquoted systemd directive values for Agent `ExecStart`, `WorkingDirectory`, and `Environment`
- add a regression assertion that the generated working directory is an absolute, unquoted path
- bump the release version to 1.2.6

## Root cause

The v1.2.5 Agent installer generated `WorkingDirectory="/path"`. systemd treats those quotes as part of the path and rejects the unit. The installer rolled back safely, but upgrades could not complete.

## Validation

- Agent unit tests: 57 passed
- Agent type check passed
- CLI unit/release-contract tests: 163 passed

No local Playwright or E2E suite was run.