### PR TITLE
release: 1.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 本文档记录 MioBridge 的重要变更。版本号遵循语义化版本规范。
 
+## [1.2.12] — 2026-07-21
+
+### Changed
+
+- Clash 默认生成配置改用 GeoData/GEOSITE 分流：启用 `geodata-mode` 与
+  MetaCubeX/meta-rules-dat 的 `geox-url`（支持自动更新），规则由手写
+  DOMAIN-SUFFIX 表迁移为 `GEOSITE` 类目（`category-ai-!cn`、`google`、
+  `cloudflare`、`github`、`docker`、流媒体、`category-social-media-!cn`、
+  `category-cryptocurrency`、`category-porn`、`category-scholar-!cn`、
+  `category-dev` 等）。内网/本机保留 IP-CIDR 直连，保证冷启动可 bootstrap
+  下载 geodata。
+- 新增 `🤖 AI 服务` 策略组：AI 流量（Gemini/AI Studio 精确入口与
+  `category-ai-!cn`）独立出口，便于钉到干净节点。
+- 健康检查地址统一为 `http://cp.cloudflare.com/generate_204`；`url-test`
+  增加 `tolerance`/`lazy`，`fallback`/`load-balance` 增加 `lazy`，
+  `load-balance` 改用 `round-robin`。
+- `MATCH` 兜底指向 `🐟 漏网之鱼`（默认代理，可一键切直连）；`category-dev`
+  置于 Apple 直连规则之后，避免其内含的 `apple.com` 覆盖 Apple 直连。
+
 ## [1.2.11] — 2026-07-21
 
 ### Added

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miobridge-agent",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "private": true,
   "type": "module",
   "scripts": {

--- a/agent/src/__tests__/handlers.test.ts
+++ b/agent/src/__tests__/handlers.test.ts
@@ -391,7 +391,7 @@ describe('handleHealth', () => {
     const body = await res.json();
     expect(body.uptime).toBeDefined();
     expect(body.memory).toBeDefined();
-    expect(body.version).toBe('1.2.11');
+    expect(body.version).toBe('1.2.12');
   });
 });
 

--- a/agent/src/version.ts
+++ b/agent/src/version.ts
@@ -1,1 +1,1 @@
-export const AGENT_VERSION = process.env.MIOBRIDGE_BUILD_VERSION ?? '1.2.11';
+export const AGENT_VERSION = process.env.MIOBRIDGE_BUILD_VERSION ?? '1.2.12';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miobridge",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "MioBridge — sing-box to Clash subscription converter powered by mihomo, supporting vless/vmess/trojan/hysteria2/tuic",
   "private": true,
   "packageManager": "bun@1.2.13",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miobridge/cli",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -8,7 +8,7 @@ import { formatLocalNodeConfiguration, type LocalNodeConfigurationService } from
 import { formatDashboardDaemonStatus, type DashboardDaemonAction } from './dashboard/commands.js';
 import type { DashboardDaemonStatus } from './dashboard/systemd.js';
 
-export const CLI_VERSION = process.env.MIOBRIDGE_BUILD_VERSION ?? '1.2.11';
+export const CLI_VERSION = process.env.MIOBRIDGE_BUILD_VERSION ?? '1.2.12';
 
 export interface CliCore {
   updateSubscription(): Promise<UpdateResult>;

--- a/packages/cli/test/headless.test.ts
+++ b/packages/cli/test/headless.test.ts
@@ -64,7 +64,7 @@ describe('headless CLI composition', () => {
     });
     expect(result.code).toBe(0);
     expect(result.stderr).toBe('');
-    expect(JSON.parse(result.stdout)).toMatchObject({ version: '1.2.11', subscriptionExists: false });
+    expect(JSON.parse(result.stdout)).toMatchObject({ version: '1.2.12', subscriptionExists: false });
     expect(await readdir(cwd)).toEqual(['.keep']);
     await rm(sandbox, { recursive: true, force: true });
   });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miobridge/core",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/src/kernels/mihomoAdapter.ts
+++ b/packages/core/src/kernels/mihomoAdapter.ts
@@ -23,6 +23,7 @@ const DNS_CONFIG = {
   nameserver: ['https://doh.pub/dns-query', 'https://dns.alidns.com/dns-query'],
 } as const;
 
+// 内网 / 本机：非 GEOSITE 规则，geodata 未加载时仍可用，保证冷启动可 bootstrap 下载 geodata
 const DEFAULT_RULES = [
   'DOMAIN-SUFFIX,local,DIRECT',
   'IP-CIDR,127.0.0.0/8,DIRECT,no-resolve',
@@ -34,72 +35,64 @@ const DEFAULT_RULES = [
   'IP-CIDR6,::1/128,DIRECT,no-resolve',
   'IP-CIDR6,fc00::/7,DIRECT,no-resolve',
   'IP-CIDR6,fe80::/10,DIRECT,no-resolve',
-  'DOMAIN-SUFFIX,cn,DIRECT',
+  // 广告拦截
+  'GEOSITE,category-ads-all,REJECT',
+  // Google AI Studio / Gemini 精确入口（放 category-ai / google 之前）
+  'DOMAIN,aistudio.google.com,🤖 AI 服务',
+  'DOMAIN,gemini.google.com,🤖 AI 服务',
+  'DOMAIN,alkalimakersuite-pa.clients6.google.com,🤖 AI 服务',
+  'DOMAIN,generativelanguage.googleapis.com,🤖 AI 服务',
+  'DOMAIN,ai.google.dev,🤖 AI 服务',
+  // 海外 AI（Claude / OpenAI / Gemini / Perplexity / Mistral 等非中国大陆）
+  'GEOSITE,category-ai-!cn,🤖 AI 服务',
+  // Google 兜底（登录 / OAuth / APIs / gstatic 等）
+  'GEOSITE,google,🚀 节点选择',
+  // Cloudflare
+  'GEOSITE,cloudflare,🚀 节点选择',
+  // 开发服务
+  'GEOSITE,github,🚀 节点选择',
+  'GEOSITE,docker,🚀 节点选择',
+  // 常见海外服务
+  'GEOSITE,microsoft,🚀 节点选择',
+  'GEOSITE,telegram,🚀 节点选择',
+  'GEOSITE,discord,🚀 节点选择',
+  // 流媒体
+  'GEOSITE,youtube,🚀 节点选择',
+  'GEOSITE,netflix,🚀 节点选择',
+  'GEOSITE,spotify,🚀 节点选择',
+  // 境外社媒（含 twitter / tiktok / reddit 等）
+  'GEOSITE,category-social-media-!cn,🚀 节点选择',
+  // 加密货币（交易所 / 行情）
+  'GEOSITE,category-cryptocurrency,🚀 节点选择',
+  // 成人内容
+  'GEOSITE,category-porn,🚀 节点选择',
+  // 学术（IEEE / Springer / arXiv 等）
+  'GEOSITE,category-scholar-!cn,🚀 节点选择',
+  // Apple
+  'GEOSITE,apple-cn,DIRECT',
+  'GEOSITE,apple,DIRECT',
+  // 开发者站点（置于 apple 之后，避免 category-dev 内的 apple.com 覆盖上面的直连）
+  'GEOSITE,category-dev,🚀 节点选择',
+  // 国内域名和 IP
+  'GEOSITE,cn,DIRECT',
   'GEOIP,CN,DIRECT,no-resolve',
-  // ── AI 服务规则（统一走「♻️ 自动选择」）──
-  // Anthropic / Claude
-  'DOMAIN-SUFFIX,anthropic.com,♻️ 自动选择',
-  'DOMAIN-SUFFIX,claude.ai,♻️ 自动选择',
-  'DOMAIN-SUFFIX,claude.com,♻️ 自动选择',
-  // OpenAI
-  'DOMAIN-SUFFIX,openai.com,♻️ 自动选择',
-  'DOMAIN-SUFFIX,chatgpt.com,♻️ 自动选择',
-  'DOMAIN-SUFFIX,oaistatic.com,♻️ 自动选择',
-  'DOMAIN-SUFFIX,oaiusercontent.com,♻️ 自动选择',
-  // Google Gemini / AI Studio（仅精确 AI 主机，避免劫持全站 Google 流量）
-  'DOMAIN-SUFFIX,gemini.google.com,♻️ 自动选择',
-  'DOMAIN-SUFFIX,ai.google.dev,♻️ 自动选择',
-  'DOMAIN,aistudio.google.com,♻️ 自动选择',
-  'DOMAIN,generativelanguage.googleapis.com,♻️ 自动选择',
-  'DOMAIN,aiplatform.googleapis.com,♻️ 自动选择',
-  'DOMAIN,alkalimakersuite-pa.clients6.google.com,♻️ 自动选择',
-  // Cloudflare AI Gateway（仅网关，不含整个 cloudflare.com）
-  'DOMAIN,gateway.ai.cloudflare.com,♻️ 自动选择',
-  // GitHub Copilot
-  'DOMAIN-SUFFIX,githubcopilot.com,♻️ 自动选择',
-  'DOMAIN-SUFFIX,copilot.github.com,♻️ 自动选择',
-  'DOMAIN,copilot-proxy.githubusercontent.com,♻️ 自动选择',
-  // AI 编辑器
-  'DOMAIN-SUFFIX,cursor.com,♻️ 自动选择',
-  'DOMAIN-SUFFIX,cursor.sh,♻️ 自动选择',
-  'DOMAIN-SUFFIX,windsurf.com,♻️ 自动选择',
-  'DOMAIN-SUFFIX,codeium.com,♻️ 自动选择',
-  // 模型 / 推理服务商
-  'DOMAIN-SUFFIX,openrouter.ai,♻️ 自动选择',
-  'DOMAIN-SUFFIX,groq.com,♻️ 自动选择',
-  'DOMAIN-SUFFIX,x.ai,♻️ 自动选择',
-  'DOMAIN-SUFFIX,grok.com,♻️ 自动选择',
-  'DOMAIN-SUFFIX,deepseek.com,♻️ 自动选择',
-  'DOMAIN-SUFFIX,deepseek.ai,♻️ 自动选择',
-  'DOMAIN-SUFFIX,mistral.ai,♻️ 自动选择',
-  'DOMAIN-SUFFIX,cohere.com,♻️ 自动选择',
-  'DOMAIN-SUFFIX,fireworks.ai,♻️ 自动选择',
-  'DOMAIN-SUFFIX,together.ai,♻️ 自动选择',
-  'DOMAIN-SUFFIX,cerebras.ai,♻️ 自动选择',
-  'DOMAIN-SUFFIX,perplexity.ai,♻️ 自动选择',
-  'DOMAIN-SUFFIX,poe.com,♻️ 自动选择',
-  'DOMAIN-SUFFIX,character.ai,♻️ 自动选择',
-  // 托管 / 部署 / 数据集
-  'DOMAIN-SUFFIX,huggingface.co,♻️ 自动选择',
-  'DOMAIN-SUFFIX,hf.space,♻️ 自动选择',
-  'DOMAIN-SUFFIX,replicate.com,♻️ 自动选择',
-  'DOMAIN-SUFFIX,fal.ai,♻️ 自动选择',
-  'DOMAIN-SUFFIX,runpod.io,♻️ 自动选择',
-  'DOMAIN-SUFFIX,modal.com,♻️ 自动选择',
-  'DOMAIN-SUFFIX,baseten.co,♻️ 自动选择',
-  // 图像 / 音频 / 视频生成
-  'DOMAIN-SUFFIX,stability.ai,♻️ 自动选择',
-  'DOMAIN-SUFFIX,midjourney.com,♻️ 自动选择',
-  'DOMAIN-SUFFIX,ideogram.ai,♻️ 自动选择',
-  'DOMAIN-SUFFIX,lumalabs.ai,♻️ 自动选择',
-  'DOMAIN-SUFFIX,suno.com,♻️ 自动选择',
-  'DOMAIN-SUFFIX,elevenlabs.io,♻️ 自动选择',
-  'DOMAIN-SUFFIX,assemblyai.com,♻️ 自动选择',
-  // Vercel v0（仅 AI 子产品，不含整个 vercel.com）
-  'DOMAIN-SUFFIX,v0.dev,♻️ 自动选择',
-  'DOMAIN-SUFFIX,vusercontent.net,♻️ 自动选择',
-  'MATCH,♻️ 自动选择',
+  // 漏网之鱼
+  'MATCH,🐟 漏网之鱼',
 ] as const;
+
+// GeoData：MetaCubeX/meta-rules-dat，支持自动更新
+const GEO_CONFIG = {
+  'geodata-mode': true,
+  'geodata-loader': 'memconservative',
+  'geo-auto-update': true,
+  'geo-update-interval': 24,
+  'geox-url': {
+    geoip: 'https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geoip-lite.dat',
+    geosite: 'https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/geosite.dat',
+    mmdb: 'https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/country-lite.mmdb',
+    asn: 'https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/GeoLite2-ASN.mmdb',
+  },
+} as const;
 
 function normalizedBinary(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
@@ -157,11 +150,12 @@ export class MihomoAdapter {
     const proxies = parsed.map(item => item.proxy).filter((value): value is ProxyConfig => value !== null);
     if (proxies.length === 0) throw new Error('未找到有效的代理节点');
     const names = proxies.map(proxy => proxy.name);
-    const yaml = YAML.stringify({ port: 7890, 'socks-port': 7891, 'allow-lan': false, mode: 'rule', 'log-level': 'info', 'external-controller': '127.0.0.1:9090', dns: DNS_CONFIG, proxies, 'proxy-groups': [
-      { name: '🚀 节点选择', type: 'select', proxies: ['♻️ 自动选择', '🔯 故障转移', '🔮 负载均衡', '🎯 全球直连', ...names] },
-      { name: '♻️ 自动选择', type: 'url-test', proxies: names, url: 'http://www.gstatic.com/generate_204', interval: 300 },
-      { name: '🔯 故障转移', type: 'fallback', proxies: names, url: 'http://www.gstatic.com/generate_204', interval: 300 },
-      { name: '🔮 负载均衡', type: 'load-balance', proxies: names, url: 'http://www.gstatic.com/generate_204', interval: 300 },
+    const yaml = YAML.stringify({ port: 7890, 'socks-port': 7891, 'allow-lan': false, mode: 'rule', 'log-level': 'info', 'external-controller': '127.0.0.1:9090', ...GEO_CONFIG, dns: DNS_CONFIG, proxies, 'proxy-groups': [
+      { name: '🚀 节点选择', type: 'select', proxies: ['♻️ 自动选择', '🤖 AI 服务', '🔯 故障转移', '🔮 负载均衡', '🎯 全球直连', ...names] },
+      { name: '🤖 AI 服务', type: 'select', proxies: ['♻️ 自动选择', '🔯 故障转移', '🚀 节点选择', ...names] },
+      { name: '♻️ 自动选择', type: 'url-test', proxies: names, url: 'http://cp.cloudflare.com/generate_204', interval: 300, tolerance: 50, lazy: true },
+      { name: '🔯 故障转移', type: 'fallback', proxies: names, url: 'http://cp.cloudflare.com/generate_204', interval: 300, lazy: true },
+      { name: '🔮 负载均衡', type: 'load-balance', proxies: names, url: 'http://cp.cloudflare.com/generate_204', interval: 300, lazy: true, strategy: 'round-robin' },
       { name: '🎯 全球直连', type: 'select', proxies: ['DIRECT'] },
       { name: '🐟 漏网之鱼', type: 'select', proxies: ['🚀 节点选择', '🎯 全球直连', '♻️ 自动选择'] },
     ], rules: DEFAULT_RULES }, { lineWidth: 0 });

--- a/packages/core/test/kernels/adapters.test.ts
+++ b/packages/core/test/kernels/adapters.test.ts
@@ -141,11 +141,11 @@ describe('kernel adapters', () => {
     expect(output.proxies).toHaveLength(2);
     expect(output.dns).toMatchObject({ enable: true, 'enhanced-mode': 'fake-ip' });
     expect(output['proxy-groups'].map((group: any) => group.name)).toEqual([
-      '🚀 节点选择', '♻️ 自动选择', '🔯 故障转移', '🔮 负载均衡', '🎯 全球直连', '🐟 漏网之鱼',
+      '🚀 节点选择', '🤖 AI 服务', '♻️ 自动选择', '🔯 故障转移', '🔮 负载均衡', '🎯 全球直连', '🐟 漏网之鱼',
     ]);
     expect(output['proxy-groups'][0].proxies).toEqual(expect.arrayContaining(['hy2', 'trojan']));
-    expect(output.rules).toContain('DOMAIN-SUFFIX,openai.com,♻️ 自动选择');
-    expect(output.rules.at(-1)).toBe('MATCH,♻️ 自动选择');
+    expect(output.rules).toContain('GEOSITE,category-ai-!cn,🤖 AI 服务');
+    expect(output.rules.at(-1)).toBe('MATCH,🐟 漏网之鱼');
     expect(process.calls.at(-1)?.options.timeout).toBe(30_000);
   });
 

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miobridge/e2e",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miobridge/frontend",
-  "version": "1.2.11",
+  "version": "1.2.12",
   "description": "Dashboard for MioBridge \u2014 sing-box to Clash converter powered by mihomo",
   "private": true,
   "packageManager": "bun@1.2.13",


### PR DESCRIPTION
## 概要

Clash 默认生成配置迁移到 GeoData/GEOSITE 分流。

## 变更

- 启用 `geodata-mode` + MetaCubeX/meta-rules-dat `geox-url`（自动更新）；手写 DOMAIN-SUFFIX 表迁移为 `GEOSITE` 类目（`category-ai-!cn`、`google`、`cloudflare`、`github`、`docker`、流媒体、`category-social-media-!cn`、`category-cryptocurrency`、`category-porn`、`category-scholar-!cn`、`category-dev`）。内网/本机保留 IP-CIDR 直连，保证冷启动可 bootstrap 下载 geodata。
- 新增 `🤖 AI 服务` 策略组，AI 流量独立出口。
- 健康检查统一 `cp.cloudflare.com/generate_204`；`url-test` 加 `tolerance`/`lazy`，`fallback`/`load-balance` 加 `lazy`，`load-balance` 用 `round-robin`。
- `MATCH` → `🐟 漏网之鱼`；`category-dev` 置于 Apple 直连之后，防其内含 `apple.com` 覆盖直连。

## 测试

- `packages/core` 51 passed；`packages/cli` 163 passed（含 headless 版本 1.2.12）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)