### PR TITLE
feat(frontend): migrate dashboard data layer to TanStack Query

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "agent": {
       "name": "miobridge-agent",
-      "version": "1.0.0",
+      "version": "1.2.12",
       "devDependencies": {
         "@types/bun": "latest",
         "@types/node": "^24.0.8",
@@ -20,7 +20,7 @@
     },
     "packages/cli": {
       "name": "@miobridge/cli",
-      "version": "1.0.0",
+      "version": "1.2.12",
       "bin": {
         "miobridge": "./dist/main.js",
       },
@@ -38,7 +38,7 @@
     },
     "packages/core": {
       "name": "@miobridge/core",
-      "version": "1.0.0",
+      "version": "1.2.12",
       "dependencies": {
         "yaml": "^2.8.1",
       },
@@ -50,7 +50,7 @@
     },
     "packages/e2e": {
       "name": "@miobridge/e2e",
-      "version": "1.0.0",
+      "version": "1.2.12",
       "devDependencies": {
         "@playwright/test": "1.61.1",
         "@types/node": "^24.0.8",
@@ -59,7 +59,7 @@
     },
     "packages/frontend": {
       "name": "@miobridge/frontend",
-      "version": "1.0.0",
+      "version": "1.2.12",
       "dependencies": {
         "@iconify/react": "^6.0.0",
         "@monaco-editor/react": "^4.7.0",
@@ -70,6 +70,7 @@
         "@radix-ui/react-tabs": "^1.1.16",
         "@radix-ui/react-tooltip": "^1.2.11",
         "@tailwindcss/postcss": "^4.1.11",
+        "@tanstack/react-query": "^5",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "ky": "^1.8.1",
@@ -349,6 +350,10 @@
     "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.1", "", { "os": "win32", "cpu": "x64" }, "sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA=="],
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.3.1", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.3.1", "@tailwindcss/oxide": "4.3.1", "postcss": "8.5.15", "tailwindcss": "4.3.1" } }, "sha512-dNJuNbdEJT/SWRuXTYP1WSamelsz3ztkUsdtWQPjrexysrTpaEPM40P/71knXiXLYEojqPOEGitVLLpPMS5T6A=="],
+
+    "@tanstack/query-core": ["@tanstack/query-core@5.101.4", "", {}, "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw=="],
+
+    "@tanstack/react-query": ["@tanstack/react-query@5.101.4", "", { "dependencies": { "@tanstack/query-core": "5.101.4" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 

--- a/docs/superpowers/plans/2026-07-21-dashboard-data-layer.md
+++ b/docs/superpowers/plans/2026-07-21-dashboard-data-layer.md
@@ -1,0 +1,555 @@
+# Dashboard Data Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the dashboard's per-page hand-rolled `useEffect` fetching with a shared TanStack Query data layer that dedupes requests, standardizes loading/error/empty states, and pauses polling on hidden tabs.
+
+**Architecture:** Introduce `@tanstack/react-query` with one `QueryClient` mounted at the app root. All reads move to per-endpoint `useQuery` hooks under `src/lib/queries/`; writes move to `useMutation` with `invalidateQueries`. A single `<QueryBoundary>` renders skeleton / inline-error-card / empty / content. Shared query keys let always-mounted `Sidebar` and the active page collapse into one request.
+
+**Tech Stack:** React 19, TanStack Query v5, ky, sonner, vitest + @testing-library/react, Tailwind.
+
+## Global Constraints
+
+- Frontend-only. No backend/API contract changes.
+- `apiService` (`src/lib/api.ts`) stays the single HTTP surface — query hooks wrap its methods, they do not call `ky` directly.
+- Preserve all existing Chinese UI copy and sonner success/failure toasts on writes.
+- `ky` GET retry limit drops to `0`; React Query owns retries (`retry: 1`).
+- Polling cadence unchanged: deploy 4s, subscription 5s, logs 5s. All polling uses `refetchIntervalInBackground: false`.
+- Tests run with `bun run test` (`vitest run --maxWorkers=1 --no-file-parallelism`) from `packages/frontend`.
+- Every test that renders a component using a query hook MUST wrap it in a `QueryClientProvider` via the shared `renderWithClient` helper (Task 4).
+
+---
+
+### Task 1: Add dependency + QueryClient + provider wiring + ky retry
+
+**Files:**
+- Modify: `packages/frontend/package.json` (dependencies)
+- Create: `packages/frontend/src/lib/queryClient.ts`
+- Modify: `packages/frontend/src/App.tsx`
+- Modify: `packages/frontend/src/lib/api.ts:77-81` (ky retry limit)
+
+**Interfaces:**
+- Produces: `queryClient` (a configured `QueryClient`) and `makeQueryClient()` from `src/lib/queryClient.ts`.
+
+- [ ] **Step 1: Add dependency**
+
+```bash
+cd packages/frontend && bun add @tanstack/react-query@^5
+```
+
+- [ ] **Step 2: Create the QueryClient factory**
+
+`src/lib/queryClient.ts`:
+
+```ts
+import { QueryClient, QueryCache } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+// Background-refresh failures (query already has cached data on screen) get a
+// toast. First-load failures render an inline error card via <QueryBoundary>,
+// so they must NOT also toast here.
+export function makeQueryClient(): QueryClient {
+  return new QueryClient({
+    queryCache: new QueryCache({
+      onError: (error, query) => {
+        if (query.state.data === undefined) return
+        const message = error instanceof Error ? error.message : '后台刷新失败'
+        toast.error('数据刷新失败', { description: message })
+      },
+    }),
+    defaultOptions: {
+      queries: {
+        staleTime: 30_000,
+        gcTime: 300_000,
+        retry: 1,
+        refetchOnWindowFocus: false,
+      },
+    },
+  })
+}
+
+export const queryClient = makeQueryClient()
+```
+
+- [ ] **Step 3: Lower ky GET retry in `src/lib/api.ts`**
+
+Change the `retry` block (currently `limit: 3`) so React Query owns retries:
+
+```ts
+  retry: {
+    limit: 0,
+    methods: [...API_RETRY_METHODS],
+    statusCodes: [408, 413, 429, 500, 502, 503, 504],
+  },
+```
+
+- [ ] **Step 4: Wrap the app in `src/App.tsx`**
+
+Add import and wrap `AppProvider`'s subtree. Inside `App()`:
+
+```tsx
+import { QueryClientProvider } from '@tanstack/react-query'
+import { queryClient } from './lib/queryClient'
+// ...
+export function App() {
+  return (
+    <ThemeProvider>
+      <QueryClientProvider client={queryClient}>
+        <AppProvider>
+          <AnimatedRoutes />
+          <Toaster richColors position="top-center" />
+        </AppProvider>
+      </QueryClientProvider>
+    </ThemeProvider>
+  )
+}
+```
+
+- [ ] **Step 5: Typecheck + build**
+
+Run: `cd packages/frontend && bun run build`
+Expected: build succeeds, no TS errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/frontend/package.json packages/frontend/bun.lock packages/frontend/src/lib/queryClient.ts packages/frontend/src/lib/api.ts packages/frontend/src/App.tsx
+git commit -m "feat(frontend): add TanStack Query client and provider"
+```
+
+---
+
+### Task 2: Skeleton primitive
+
+**Files:**
+- Create: `packages/frontend/src/components/ui/skeleton.tsx`
+
+**Interfaces:**
+- Produces: `Skeleton` component — `(props: React.HTMLAttributes<HTMLDivElement>) => JSX.Element`.
+
+- [ ] **Step 1: Create the primitive** (matches existing `PageLoader` pulse style)
+
+```tsx
+import { cn } from '@/lib/utils'
+
+export function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('animate-pulse rounded-md bg-muted', className)} {...props} />
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/frontend/src/components/ui/skeleton.tsx
+git commit -m "feat(frontend): add Skeleton primitive"
+```
+
+---
+
+### Task 3: QueryBoundary component
+
+**Files:**
+- Create: `packages/frontend/src/components/shared/QueryBoundary.tsx`
+- Test: `packages/frontend/src/components/shared/__tests__/query-boundary.test.tsx`
+
+**Interfaces:**
+- Consumes: `Skeleton` (Task 2).
+- Produces:
+  ```ts
+  interface QueryBoundaryProps<T> {
+    query: Pick<UseQueryResult<T>, 'data' | 'isPending' | 'isError' | 'error' | 'refetch'>
+    skeleton?: React.ReactNode        // first-load placeholder; default: generic skeleton block
+    isEmpty?: (data: T) => boolean    // treat success-with-no-rows as empty state
+    empty?: React.ReactNode           // empty-state node; default generic
+    children: (data: T) => React.ReactNode
+  }
+  function QueryBoundary<T>(props: QueryBoundaryProps<T>): JSX.Element
+  ```
+
+- [ ] **Step 1: Write failing tests**
+
+`__tests__/query-boundary.test.tsx`:
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { QueryBoundary } from '../QueryBoundary'
+
+const base = { data: undefined, isPending: false, isError: false, error: null, refetch: vi.fn() }
+
+describe('QueryBoundary', () => {
+  it('renders skeleton while first load pending', () => {
+    render(<QueryBoundary query={{ ...base, isPending: true }} skeleton={<div>SKELE</div>}>{() => <div>DATA</div>}</QueryBoundary>)
+    expect(screen.getByText('SKELE')).toBeInTheDocument()
+  })
+
+  it('renders error card with retry that calls refetch', () => {
+    const refetch = vi.fn()
+    render(<QueryBoundary query={{ ...base, isError: true, error: new Error('boom'), refetch }}>{() => <div>DATA</div>}</QueryBoundary>)
+    expect(screen.getByText('boom')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /重试/ }))
+    expect(refetch).toHaveBeenCalledOnce()
+  })
+
+  it('renders empty state when isEmpty true', () => {
+    render(<QueryBoundary query={{ ...base, data: [] }} isEmpty={(d: unknown[]) => d.length === 0} empty={<div>EMPTY</div>}>{() => <div>DATA</div>}</QueryBoundary>)
+    expect(screen.getByText('EMPTY')).toBeInTheDocument()
+  })
+
+  it('renders children on success with data', () => {
+    render(<QueryBoundary query={{ ...base, data: [1] }}>{(d: number[]) => <div>rows:{d.length}</div>}</QueryBoundary>)
+    expect(screen.getByText('rows:1')).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `bun run test -- query-boundary`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement `QueryBoundary.tsx`**
+
+```tsx
+import type { UseQueryResult } from '@tanstack/react-query'
+import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Icon } from '@iconify/react'
+
+interface QueryBoundaryProps<T> {
+  query: Pick<UseQueryResult<T>, 'data' | 'isPending' | 'isError' | 'error' | 'refetch'>
+  skeleton?: React.ReactNode
+  isEmpty?: (data: T) => boolean
+  empty?: React.ReactNode
+  children: (data: T) => React.ReactNode
+}
+
+export function QueryBoundary<T>({ query, skeleton, isEmpty, empty, children }: QueryBoundaryProps<T>) {
+  if (query.isPending) {
+    return <>{skeleton ?? <Skeleton className="h-40 w-full" />}</>
+  }
+  if (query.isError) {
+    const message = query.error instanceof Error ? query.error.message : '加载失败'
+    return (
+      <div className="flex flex-col items-center gap-3 rounded-2xl border border-destructive/30 bg-destructive/5 p-8 text-center">
+        <Icon icon="ph:warning-circle-light" className="size-8 text-destructive" />
+        <p className="text-sm text-destructive">{message}</p>
+        <Button size="sm" variant="outline" onClick={() => { void query.refetch() }}>重试</Button>
+      </div>
+    )
+  }
+  const data = query.data as T
+  if (isEmpty?.(data)) {
+    return <>{empty ?? <p className="py-8 text-center text-sm text-muted-foreground">暂无数据</p>}</>
+  }
+  return <>{children(data)}</>
+}
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `bun run test -- query-boundary`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/frontend/src/components/shared/QueryBoundary.tsx packages/frontend/src/components/shared/__tests__/query-boundary.test.tsx
+git commit -m "feat(frontend): add QueryBoundary with skeleton/error/empty states"
+```
+
+---
+
+### Task 4: Query key registry + read hooks + test helper
+
+**Files:**
+- Create: `packages/frontend/src/lib/queries/keys.ts`
+- Create: `packages/frontend/src/lib/queries/index.ts`
+- Create: `packages/frontend/src/test/renderWithClient.tsx`
+- Test: `packages/frontend/src/lib/queries/__tests__/queries.test.tsx`
+
+**Interfaces:**
+- Consumes: `apiService` methods (`src/lib/api.ts`).
+- Produces (read hooks, all returning `UseQueryResult<...>`):
+  - `useClusterStatus()` → data `ClusterStatus` (from `apiService.getClusterStatus()` → `response.data`)
+  - `useStatus()` → `ApiStatus`
+  - `useMetrics(range: '24h'|'7d'|'30d')` → `{ snapshot; history; summary }`
+  - `useComponentStates(nodeIds?: string[])` → `ComponentState[]`
+  - `useComponentDeployments(nodeIds?: string[])` → `Record<string, ComponentDeployStatus>`
+  - `useSubscriptionJobs()` → `SubscriptionJob[]`
+  - `useSubscriptionPolicy()` → `SubscriptionPolicy`
+  - `useSubscriptionPreflight()` → `SubscriptionPreflight`
+  - `useArtifacts()` → `ArtifactState[]`
+  - `useConfigSchema()` / `useEffectiveConfig()`
+  - `useNotificationHistory()` → records array
+  - `useOpenApi()` → document
+  - `useLogs(params)` → `LogsResult`
+- Produces: `queryKeys` object; `renderWithClient(ui)` test helper.
+
+Notes for the implementer: each read hook unwraps `apiService` the same way the current pages do (e.g. `getClusterStatus()` returns `ApiResponse`, pages read `.data`; if `response.success === false` throw `new Error(serverErrorMessage)` so QueryBoundary shows it). Keep unwrap logic in the hook's `queryFn`.
+
+- [ ] **Step 1: Write the test helper** `src/test/renderWithClient.tsx`
+
+```tsx
+import { render } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+export function makeTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+}
+
+export function renderWithClient(ui: React.ReactElement, client = makeTestClient()) {
+  return { client, ...render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>) }
+}
+```
+
+- [ ] **Step 2: Write failing test** `queries.test.tsx` (dedup: two hooks, one fetch)
+
+```tsx
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { apiService } from '@/lib/api'
+import { useClusterStatus } from '@/lib/queries'
+
+describe('useClusterStatus', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  it('dedupes concurrent callers into one apiService call', async () => {
+    const spy = vi.spyOn(apiService, 'getClusterStatus').mockResolvedValue({ success: true, data: { nodes: [] }, timestamp: '' } as any)
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const wrapper = ({ children }: { children: React.ReactNode }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    const a = renderHook(() => useClusterStatus(), { wrapper })
+    const b = renderHook(() => useClusterStatus(), { wrapper })
+    await waitFor(() => expect(a.result.current.data).toBeDefined())
+    await waitFor(() => expect(b.result.current.data).toBeDefined())
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+})
+```
+
+- [ ] **Step 3: Run, verify fail**
+
+Run: `bun run test -- queries`
+Expected: FAIL (module `@/lib/queries` not found).
+
+- [ ] **Step 4: Implement `keys.ts`**
+
+```ts
+export const queryKeys = {
+  clusterStatus: ['cluster-status'] as const,
+  status: ['status'] as const,
+  metrics: (range: string) => ['metrics', range] as const,
+  componentStates: (nodeIds?: string[]) => ['component-states', nodeIds ?? null] as const,
+  componentDeployments: (nodeIds?: string[]) => ['component-deployments', nodeIds ?? null] as const,
+  subscriptionJobs: ['subscription-jobs'] as const,
+  subscriptionPolicy: ['subscription-policy'] as const,
+  subscriptionPreflight: ['subscription-preflight'] as const,
+  artifacts: ['artifacts'] as const,
+  configSchema: ['config-schema'] as const,
+  effectiveConfig: ['effective-config'] as const,
+  notificationHistory: ['notification-history'] as const,
+  openApi: ['openapi'] as const,
+  logs: (key: string) => ['logs', key] as const,
+}
+```
+
+- [ ] **Step 5: Implement `index.ts`** — one `useQuery` per endpoint. Representative entries (implementer repeats the pattern for every hook in Interfaces):
+
+```ts
+import { useQuery } from '@tanstack/react-query'
+import { apiService } from '@/lib/api'
+import { queryKeys } from './keys'
+import type { ClusterStatus } from '@/lib/types' // adjust to actual type location
+
+function unwrap<T>(res: { success: boolean; data?: T; error?: unknown }): T {
+  if (!res.success || res.data === undefined) {
+    const msg = typeof res.error === 'string' ? res.error : '请求失败'
+    throw new Error(msg)
+  }
+  return res.data
+}
+
+export function useClusterStatus() {
+  return useQuery({
+    queryKey: queryKeys.clusterStatus,
+    queryFn: async () => unwrap<ClusterStatus>(await apiService.getClusterStatus()),
+  })
+}
+
+export function useStatus() {
+  return useQuery({ queryKey: queryKeys.status, queryFn: () => apiService.getStatus() })
+}
+
+export function useMetrics(range: '24h' | '7d' | '30d') {
+  return useQuery({
+    queryKey: queryKeys.metrics(range),
+    queryFn: async () => unwrap(await apiService.getMetrics(range)),
+  })
+}
+// ...remaining hooks follow the same unwrap/useQuery shape.
+export { queryKeys } from './keys'
+```
+
+- [ ] **Step 6: Run, verify pass**
+
+Run: `bun run test -- queries`
+Expected: PASS (dedup test: spy called once).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/frontend/src/lib/queries packages/frontend/src/test/renderWithClient.tsx
+git commit -m "feat(frontend): add query key registry and read hooks"
+```
+
+---
+
+### Task 5: Mutation hooks
+
+**Files:**
+- Create: `packages/frontend/src/lib/queries/mutations.ts`
+- Modify: `packages/frontend/src/lib/queries/index.ts` (re-export)
+- Test: `packages/frontend/src/lib/queries/__tests__/mutations.test.tsx`
+
+**Interfaces:**
+- Consumes: `apiService` write methods, `queryKeys`.
+- Produces mutation hooks that invalidate affected keys on success. Group by domain:
+  - Node writes → invalidate `clusterStatus`: `useUpdateNode`, `useDeleteNode`, `useAddNode`, `useUpdateNodeKernels`
+  - Agent actions → invalidate `clusterStatus`: `useAgentAction` (start/stop/restart), `useClusterHealthCheck`
+  - Kernel → invalidate `componentStates` + `clusterStatus`: `useKernelAction`
+  - Deploy → invalidate `componentDeployments` + `componentStates`: `useStartDeployment`, `useRetryDeployment`, `useCancelDeployment`
+  - Subscription → invalidate `subscriptionJobs`: `useStartSubscriptionJob`, `useRetrySubscriptionJob`, `useUpdateSubscriptionPolicy` (invalidate `subscriptionPolicy`)
+  - Config → invalidate `effectiveConfig`: `usePatchConfigValues`, `useRestoreConfig`
+
+- [ ] **Step 1: Write failing test** (representative: `useUpdateNode` invalidates cluster status)
+
+```tsx
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, it, expect, vi } from 'vitest'
+import { apiService } from '@/lib/api'
+import { queryKeys } from '@/lib/queries'
+import { useUpdateNode } from '@/lib/queries/mutations'
+
+it('invalidates cluster status after updateNode', async () => {
+  vi.spyOn(apiService, 'updateNode').mockResolvedValue({ success: true, data: {}, timestamp: '' } as any)
+  const client = new QueryClient()
+  const spy = vi.spyOn(client, 'invalidateQueries')
+  const wrapper = ({ children }: { children: React.ReactNode }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  const { result } = renderHook(() => useUpdateNode(), { wrapper })
+  await result.current.mutateAsync({ nodeId: 'n1', patch: { enabled: true } })
+  await waitFor(() => expect(spy).toHaveBeenCalledWith({ queryKey: queryKeys.clusterStatus }))
+})
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `bun run test -- mutations`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement `mutations.ts`** — representative:
+
+```ts
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { apiService } from '@/lib/api'
+import { queryKeys } from './keys'
+
+export function useUpdateNode() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (vars: { nodeId: string; patch: Parameters<typeof apiService.updateNode>[1] }) =>
+      apiService.updateNode(vars.nodeId, vars.patch),
+    onSuccess: () => { void qc.invalidateQueries({ queryKey: queryKeys.clusterStatus }) },
+  })
+}
+// ...remaining mutation hooks follow the same shape, invalidating the keys listed in Interfaces.
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `bun run test -- mutations`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/frontend/src/lib/queries/mutations.ts packages/frontend/src/lib/queries/index.ts packages/frontend/src/lib/queries/__tests__/mutations.test.tsx
+git commit -m "feat(frontend): add mutation hooks with query invalidation"
+```
+
+---
+
+### Tasks 6–18: Migrate consumers
+
+Each consumer task follows the SAME recipe. Do them one file per task, committing after each so a reviewer can gate independently.
+
+**Recipe (apply per file):**
+1. Delete the file's data-fetch `useState` (`cluster`, `error`, list state that mirrors server data) and its `useEffect` + `refresh()` fetch, and any `setInterval`.
+2. Call the relevant read hook(s) from `@/lib/queries`. For polling files, pass `refetchInterval` + `refetchIntervalInBackground: false` by having the hook accept an options override OR wrap with a local `useQuery` option (add an optional `options` param to the polling hooks — `useComponentDeployments`, `useSubscriptionJobs`, `useLogs`).
+3. Wrap the data-rendering region in `<QueryBoundary>` with a page-appropriate `skeleton` and, where a list can be legitimately empty, `isEmpty` + `empty`.
+4. Replace write calls with the Task 5 mutation hooks; keep existing success/error `toast` calls in `onSuccess`/`onError` (or around `mutateAsync`).
+5. Remove now-dead local error rendering superseded by `<QueryBoundary>` / toast.
+6. Update that file's existing test(s) to render via `renderWithClient` and mock `apiService`.
+7. Run `bun run test` for the affected test, then `bun run build`. Commit.
+
+**Per-file endpoint map (what each consumes):**
+
+- **Task 6 — `components/layout/Sidebar.tsx`**: `useStatus()` (was `getStatus` → `mihomoAvailable`). Always-mounted; sharing the key with Dashboard is the primary dedup win.
+- **Task 7 — `components/Dashboard.tsx`**: `useStatus()`, `useClusterStatus()`, `useMetrics(range)`. Update tests `dashboard-metrics-race.test.tsx`, `dashboard-refresh-error.test.tsx` to the new hooks (these currently assert on the old fetch/race + error behavior — rewrite them against `renderWithClient` + mocked `apiService`, asserting metrics race resolved by query keying and error surfaced via QueryBoundary).
+- **Task 8 — `pages/nodes.tsx`**: `useClusterStatus()`; writes `useUpdateNode`, `useDeleteNode`, `useAddNode`. Update `nodes-kernel-edit.test.tsx`, `local-node-display.test.tsx` to `renderWithClient`.
+- **Task 9 — `pages/agents.tsx`**: `useClusterStatus()`; `useAgentAction`, `useClusterHealthCheck`.
+- **Task 10 — `pages/runtimes.tsx`**: `useClusterStatus()`, `useComponentStates([nodeId])`, kernel `detectKernels` (keep as on-demand query enabled by node selection, or `useMutation` since it's a POST); writes `useUpdateNodeKernels`, `useKernelAction`. Update `cluster-components.test.tsx`, `kernel-detection-dialog.test.tsx`.
+- **Task 11 — `pages/deploy.tsx`**: `useClusterStatus()`, `useComponentDeployments()` (poll 4s), `useComponentStates()`; writes `useStartDeployment`, `useRetryDeployment`, `useCancelDeployment`, `useClusterHealthCheck`. Keep SSE wiring; on SSE message call `queryClient.invalidateQueries` for deployments instead of manual `refresh()`.
+- **Task 12 — `pages/subscription.tsx`**: `useClusterStatus()`, `useSubscriptionPreflight()`, `useSubscriptionJobs()` (poll 5s); writes `useStartSubscriptionJob`, `useRetrySubscriptionJob`. Keep SSE; invalidate `subscriptionJobs` on message.
+- **Task 13 — `pages/subscription-status.tsx`**: `useStatus()`, `useArtifacts()`, `useSubscriptionJobs()`, `useSubscriptionPolicy()`; write `useUpdateSubscriptionPolicy`.
+- **Task 14 — `pages/outputs.tsx`**: `useArtifacts()`; `previewArtifact`/`validateArtifacts` stay as on-demand actions (mutation or manual `queryClient.fetchQuery`), invalidate `artifacts` after validate.
+- **Task 15 — `pages/config.tsx`**: `useConfigSchema()`, `useEffectiveConfig()`, `useNotificationHistory()`; writes `usePatchConfigValues`, `useRestoreConfig`, and keep `validateConfigSource`/`previewConfigImport`/`testWebhook` as actions.
+- **Task 16 — `pages/logs.tsx`**: `useLogs(params)` (poll 5s) + `useClusterStatus()` for node list. Update `logs.test.ts`.
+- **Task 17 — `pages/api-docs.tsx`**: `useOpenApi()`. Update `api-docs.test.ts`.
+- **Task 18 — `pages/actions.tsx`**: `updateSubscription` is a POST action → `useMutation`; no read migration needed beyond wiring the toast. Small file — verify no leftover fetch state.
+
+Each task's steps:
+- [ ] Rewrite the file per recipe.
+- [ ] Update/rewrite that file's existing test(s) to `renderWithClient` + mocked `apiService`; run `bun run test -- <name>` green.
+- [ ] `bun run build` green.
+- [ ] Commit `refactor(frontend): migrate <file> to query hooks`.
+
+---
+
+### Task 19: Cleanup + full verification
+
+**Files:** repo-wide (frontend).
+
+- [ ] **Step 1: Grep for leftovers**
+
+```bash
+cd packages/frontend
+grep -rn "setInterval\|\.catch(() => {})" src/pages src/components | grep -v test
+```
+Expected: no data-fetch `setInterval` or swallowed `.catch(() => {})` remain (SSE reconnect timers excepted).
+
+- [ ] **Step 2: Full test suite**
+
+Run: `bun run test`
+Expected: all green.
+
+- [ ] **Step 3: Lint + build**
+
+Run: `bun run lint && bun run build`
+Expected: clean.
+
+- [ ] **Step 4: Commit any cleanup**
+
+```bash
+git commit -am "chore(frontend): remove dead fetch state after query migration"
+```
+
+---
+
+## Self-Review Notes
+
+- Spec §Decisions all mapped: library (T1), all-at-once scope (T6–18), skeleton (T2), inline error card + retry (T3), background-failure toast (T1 QueryCache.onError), polling refetchInterval + hidden pause (T11/12/16 + global `refetchOnWindowFocus:false`), useMutation writes (T5, applied T8–15).
+- Empty vs error distinguished in `<QueryBoundary>` (T3).
+- Existing tests touching migrated files are explicitly called out for rewrite (T7,8,10,16,17).
+- Type names (`ClusterStatus`, `ApiStatus`, etc.) come from `@/lib/types` / `@/lib/api`; implementer confirms exact import path when wiring each hook.

--- a/docs/superpowers/specs/2026-07-21-dashboard-data-layer-design.md
+++ b/docs/superpowers/specs/2026-07-21-dashboard-data-layer-design.md
@@ -1,0 +1,145 @@
+# Dashboard Data Layer Redesign
+
+Date: 2026-07-21
+Status: Approved design, pending implementation plan
+
+## Problem
+
+The Vite dashboard (`packages/frontend`) has no shared data-fetching layer.
+Each page and several always-mounted components fetch independently in their
+own `useEffect`, producing four user-visible defects:
+
+1. **Duplicate requests.** `getClusterStatus` alone is called independently by
+   8+ places (`Sidebar`, `Dashboard`, `nodes`, `deploy`, `logs`, `runtimes`,
+   `agents`, `subscription`, `subscription-status`). Because `Sidebar` is always
+   mounted, navigating to any page fires the same endpoint at least twice
+   simultaneously. Nothing dedupes or caches these calls.
+2. **Compounding polling.** `deploy.tsx` polls every 4s, `subscription.tsx` and
+   `logs.tsx` every 5s via raw `setInterval`, with no dedup and no pause when the
+   tab is hidden.
+3. **No loading feedback.** First-load latency shows nothing useful; layout is
+   empty until data resolves.
+4. **Silent failures.** Error handling is inconsistent — some callers use
+   `.catch(() => {})` and swallow errors, others fall through to an empty list.
+   A failed request renders as a blank list with no explanation and no retry.
+
+## Goals
+
+- Eliminate duplicate simultaneous requests for the same endpoint.
+- Give every data-backed view a clear first-load state, error state, and empty
+  state — three distinct states, never conflated.
+- Preserve existing polling cadence but pause it when the tab is hidden.
+- Keep writes consistent with reads (a successful write refreshes affected data
+  automatically).
+
+## Decisions (agreed)
+
+- **Library:** adopt `@tanstack/react-query`.
+- **Scope:** migrate all pages, `Sidebar`, and `Dashboard` in one pass.
+- **Loading UX:** skeleton screens (placeholder shapes matching real layout).
+- **Error UX:** inline error card with a retry button, scoped to the failed
+  region; distinct from the empty state. Background-refresh failures (data
+  already on screen) additionally raise a sonner toast.
+- **Polling:** `refetchInterval` per hook, `refetchIntervalInBackground: false`.
+- **Writes:** migrate to `useMutation` with `invalidateQueries`.
+
+## Architecture
+
+### Root wiring — `App.tsx`
+
+Mount `QueryClientProvider` wrapping `AppProvider`. A single `QueryClient` with
+defaults:
+
+- `staleTime: 30_000` — a freshly-mounted component reusing a live query key
+  does not trigger a duplicate network fetch.
+- `gcTime: 300_000` (5 min).
+- `retry: 1`.
+
+`ky` currently retries GET up to 3 times (`api.ts` `retry.limit: 3`). Stacking
+that under React Query's retry means a failed GET blocks through 3 ky attempts
+before React Query even sees the error, delaying the inline error card. Resolve
+by lowering ky's GET retry limit to `0` and letting React Query own retries.
+
+### Query hooks — `src/lib/queries/`
+
+One hook per read endpoint, each wrapping the existing `apiService` method and
+exposing a stable `queryKey`:
+
+- `useClusterStatus()` → `apiService.getClusterStatus()`, key `['cluster-status']`
+- `useStatus()` → `apiService.getStatus()`
+- `useMetrics(range)` → key `['metrics', range]`
+- `useComponentStates(nodeIds?)`, `useDeployStatus`, `useSubscriptionJobs`,
+  `useLogs(...)`, `useArtifacts`, `useConfigs`, etc. — one per current GET.
+
+Because `Sidebar` and the active page both call `useClusterStatus()`, React
+Query collapses them into a single in-flight request plus a shared cache entry.
+This is the core fix for defect #1.
+
+Query keys are centralized (e.g. a `queryKeys` object) so mutations can
+invalidate precisely.
+
+### Shared UX component — `<QueryBoundary>`
+
+A single component consumes a query result and renders one of three states:
+
+- **loading (first load):** skeleton (`ui/skeleton.tsx`, new).
+- **error:** inline error card — icon, `error.message`, retry button calling
+  `refetch()`.
+- **success:** if data is empty → dedicated empty state; otherwise children.
+
+Background refetches do not blank the screen; stale data stays visible.
+
+New primitive: `ui/skeleton.tsx`. Per-page skeleton shapes (table rows, cards)
+are composed from it to match each view's real layout.
+
+### Global background-failure toast
+
+Configure `QueryCache.onError`: raise a sonner toast **only** when the failing
+query already has cached data (i.e. a background refresh failed while content is
+visible). First-load errors are handled by the inline card, so they do not also
+toast.
+
+### Polling
+
+Remove the raw `setInterval` blocks in `deploy.tsx`, `subscription.tsx`,
+`logs.tsx`. Move cadence into the relevant hook's `refetchInterval` (4s / 5s /
+5s respectively) with `refetchIntervalInBackground: false`.
+
+### Writes — `useMutation`
+
+Migrate write paths (`deployNode`, `addNode`, `updateNode`, `deleteNode`,
+kernel actions, agent actions, subscription jobs, config patches, etc.) to
+`useMutation`. On success, `invalidateQueries` for the affected keys so reads
+refresh automatically. Preserve existing success/failure sonner toasts.
+
+### Cleanup
+
+Delete per-page hand-written `useEffect` fetches, `.catch(() => {})` swallows,
+and per-page `loading`/`error` `useState`, now superseded by the query hooks and
+`<QueryBoundary>`.
+
+## Testing
+
+- vitest + @testing-library/react (already present).
+- Test renders wrap children in a `QueryClientProvider` (a shared test helper).
+- Cover `<QueryBoundary>` three states: skeleton on first load, error card +
+  retry invokes `refetch`, empty state on empty success.
+- Cover representative query hooks (dedup / key stability) and at least one
+  mutation invalidation path.
+
+## Out of scope
+
+- Migrating polling to SSE push (`lib/sse.ts` exists but this is a larger change
+  deferred to a later effort).
+- Backend/API changes — this is a frontend-only redesign.
+
+## Affected files (indicative)
+
+- `packages/frontend/package.json` — add dependency.
+- `packages/frontend/src/App.tsx` — provider.
+- `packages/frontend/src/lib/api.ts` — ky retry limit.
+- `packages/frontend/src/lib/queries/*` — new hooks (new dir).
+- `packages/frontend/src/components/ui/skeleton.tsx` — new.
+- `packages/frontend/src/components/shared/QueryBoundary.tsx` — new.
+- All `packages/frontend/src/pages/*.tsx`, `Sidebar.tsx`, `Dashboard.tsx` —
+  migrated to hooks + `<QueryBoundary>`.

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@miobridge/frontend",
   "version": "1.2.12",
-  "description": "Dashboard for MioBridge \u2014 sing-box to Clash converter powered by mihomo",
+  "description": "Dashboard for MioBridge — sing-box to Clash converter powered by mihomo",
   "private": true,
   "packageManager": "bun@1.2.13",
   "scripts": {
@@ -21,6 +21,7 @@
     "@radix-ui/react-tabs": "^1.1.16",
     "@radix-ui/react-tooltip": "^1.2.11",
     "@tailwindcss/postcss": "^4.1.11",
+    "@tanstack/react-query": "^5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "ky": "^1.8.1",

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -2,7 +2,9 @@ import React, { Suspense, lazy } from 'react';
 import { Navigate, Routes, Route, useLocation } from 'react-router-dom';
 import { AnimatePresence, motion } from 'motion/react';
 import { Toaster } from 'sonner';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from './components/ThemeProvider';
+import { queryClient } from './lib/queryClient';
 import { AppProvider, useAppContext } from './context/AppContext';
 import AppLayout from './components/layout/AppLayout';
 
@@ -80,10 +82,12 @@ function AnimatedRoutes() {
 export function App() {
   return (
     <ThemeProvider>
-      <AppProvider>
-        <AnimatedRoutes />
-        <Toaster richColors position="top-center" />
-      </AppProvider>
+      <QueryClientProvider client={queryClient}>
+        <AppProvider>
+          <AnimatedRoutes />
+          <Toaster richColors position="top-center" />
+        </AppProvider>
+      </QueryClientProvider>
     </ThemeProvider>
   );
 }

--- a/packages/frontend/src/components/Dashboard.tsx
+++ b/packages/frontend/src/components/Dashboard.tsx
@@ -1,8 +1,9 @@
 import { Icon } from '@iconify/react'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { apiService, type ApiStatus } from '@/lib/api'
-import type { ClusterStatus, MetricsSnapshot, MetricsSummary } from '@/lib/types'
+import type { ApiStatus } from '@/lib/api'
+import type { ClusterStatus } from '@/lib/types'
+import { useClusterStatus, useMetrics, useStatus } from '@/lib/queries'
 import { useBackendReachable } from '@/context/AppContext'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
@@ -46,53 +47,28 @@ function formatBytes(value?: number) {
 
 export default function Dashboard({ initialCluster = null, initialStatus = null, initialError = null }: DashboardProps) {
   const backendReachable = useBackendReachable()
-  const [status, setStatus] = useState(initialStatus)
-  const [cluster, setCluster] = useState(initialCluster)
-  const [error, setError] = useState<string | null>(initialError)
   const [metricRange, setMetricRange] = useState<'24h' | '7d' | '30d'>('24h')
-  const [metrics, setMetrics] = useState<{ snapshot: MetricsSnapshot; history: MetricsSnapshot[]; summary: MetricsSummary } | null>(null)
 
-  // 每次刷新领一个序号，只有最新那次的响应可以写入状态。切换指标窗口会立刻发起
-  // 新请求，而先发的请求完全可能后到；不做丢弃的话它会把新窗口的数据覆盖回旧数据，
-  // 出现「按钮高亮 30d、图表画的却是 24h」这种界面自相矛盾的状态。
-  const requestSeq = useRef(0)
+  // 传入初始数据时（静态预览）挂载不自动拉取；否则三条查询各自加载。
+  // Sidebar 也调用 useStatus()，同 key 合并为单请求；指标按 range 分 key 缓存，
+  // 切换窗口时旧窗口的迟到响应写入的是旧 key，不会覆盖当前窗口——竞态由 key 天然消解。
+  const live = initialStatus === null && initialCluster === null
+  const statusQuery = useStatus({ enabled: live, ...(initialStatus ? { initialData: initialStatus } : {}) })
+  const clusterQuery = useClusterStatus({ enabled: live, ...(initialCluster ? { initialData: initialCluster } : {}) })
+  const metricsQuery = useMetrics(metricRange, { enabled: live })
 
-  /** 返回 false 表示这次响应已被更新的请求取代，没有写入任何状态。 */
-  const refresh = useCallback(async (): Promise<boolean> => {
-    const seq = ++requestSeq.current
-    let responses
-    try {
-      responses = await Promise.all([
-        apiService.getStatus(),
-        apiService.getClusterStatus(),
-        apiService.getMetrics(metricRange),
-      ])
-    } catch (error) {
-      // 过期请求的失败同样要丢弃：新窗口已经加载成功时，不该再弹一条旧窗口的错误。
-      if (seq !== requestSeq.current) return false
-      throw error
-    }
-    if (seq !== requestSeq.current) return false
-    const [nextStatus, nextCluster, nextMetrics] = responses
-    setStatus(nextStatus)
-    if (nextCluster.success) setCluster(nextCluster.data as ClusterStatus)
-    if (nextMetrics.success && nextMetrics.data) setMetrics(nextMetrics.data)
-    return true
-  }, [metricRange])
+  const status = statusQuery.data ?? null
+  const cluster = (clusterQuery.data ?? null) as ClusterStatus | null
+  const metrics = metricsQuery.data ?? null
+  const error = initialError
+    ?? (statusQuery.error ?? clusterQuery.error ?? metricsQuery.error)?.message
+    ?? null
 
-  // 首次加载和刷新按钮共用同一条失败路径。把 refresh 直接交给 onClick 的话，
-  // 失败只会变成一条未捕获的 promise rejection，用户点了按钮什么都看不到。
-  // 只有真正写入了状态才清除旧错误：被取代的过期响应不足以证明后端已经恢复。
   const runRefresh = useCallback(() => {
-    refresh()
-      .then(applied => { if (applied) setError(null) })
-      .catch((err: unknown) => setError(err instanceof Error ? err.message : '加载失败'))
-  }, [refresh])
-
-  useEffect(() => {
-    if (initialStatus !== null || initialCluster !== null) return
-    runRefresh()
-  }, [initialCluster, initialStatus, runRefresh])
+    void statusQuery.refetch()
+    void clusterQuery.refetch()
+    void metricsQuery.refetch()
+  }, [statusQuery, clusterQuery, metricsQuery])
 
   const missingFiles = status ? FILES.filter(file => !status[file.key]) : FILES
   const managedNodes = cluster?.nodes || []

--- a/packages/frontend/src/components/__tests__/dashboard-metrics-race.test.tsx
+++ b/packages/frontend/src/components/__tests__/dashboard-metrics-race.test.tsx
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { MetricsSnapshot, MetricsSummary } from '@/lib/types'
 
 const mocks = vi.hoisted(() => ({ getMetrics: vi.fn(), getStatus: vi.fn(), getClusterStatus: vi.fn() }))
@@ -54,7 +55,12 @@ describe('Dashboard 指标窗口竞态', () => {
       range === '24h' ? slow24h.promise : fast30d.promise)
 
     const Dashboard = (await import('@/components/Dashboard')).default
-    render(<MemoryRouter><Dashboard /></MemoryRouter>)
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter><Dashboard /></MemoryRouter>
+      </QueryClientProvider>,
+    )
 
     // 挂载时按默认的 24h 发起请求，此时切到 30d，两个请求同时在途。
     await waitFor(() => expect(mocks.getMetrics).toHaveBeenCalledWith('24h'))
@@ -68,7 +74,7 @@ describe('Dashboard 指标窗口竞态', () => {
     slow24h.resolve(metricsWith(24))
     await new Promise(res => setTimeout(res, 0))
 
-    // 按钮高亮的是 30d，图表就必须还是 30d 的数据。
+    // 当前窗口是 30d：迟到的 24h 响应写入的是 ['metrics','24h'] 缓存，不影响当前视图。
     expect(screen.getByText('30 个快照样本')).toBeDefined()
     expect(screen.queryByText('24 个快照样本')).toBeNull()
   })

--- a/packages/frontend/src/components/__tests__/dashboard-refresh-error.test.tsx
+++ b/packages/frontend/src/components/__tests__/dashboard-refresh-error.test.tsx
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 const mocks = vi.hoisted(() => ({ getMetrics: vi.fn(), getStatus: vi.fn(), getClusterStatus: vi.fn() }))
 
@@ -19,14 +20,19 @@ const initialStatus = {
 }
 
 function renderDashboard(Dashboard: React.ComponentType<{ initialStatus?: typeof initialStatus }>) {
-  // 传入初始数据，挂载时不会自动拉取，这样点击才是唯一的请求来源。
-  return render(<MemoryRouter><Dashboard initialStatus={initialStatus} /></MemoryRouter>)
+  // 传入初始数据，挂载时查询处于禁用状态，不会自动拉取；点击刷新才是唯一请求来源。
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter><Dashboard initialStatus={initialStatus} /></MemoryRouter>
+    </QueryClientProvider>,
+  )
 }
 
 describe('Dashboard 刷新失败反馈', () => {
   beforeEach(() => {
     mocks.getClusterStatus.mockResolvedValue({ success: true, data: null })
-    mocks.getMetrics.mockResolvedValue({ success: true, data: null })
+    mocks.getMetrics.mockResolvedValue({ success: true, data: { snapshot: {}, history: [], summary: {} } })
   })
 
   it('点击刷新失败时把错误告诉用户，而不是静默吞掉', async () => {

--- a/packages/frontend/src/components/cluster/__tests__/cluster-dashboard.test.tsx
+++ b/packages/frontend/src/components/cluster/__tests__/cluster-dashboard.test.tsx
@@ -2,12 +2,21 @@
 import { describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 vi.mock('@/lib/api', () => ({ apiService: {
   getStatus: vi.fn().mockResolvedValue({}), getClusterStatus: vi.fn().mockResolvedValue({ success: true, data: null }),
+  getConfigSchema: vi.fn().mockResolvedValue({ success: true, data: { fields: [] } }),
+  getEffectiveConfig: vi.fn().mockResolvedValue({ success: true, data: { config: {}, path: '' } }),
+  getMetrics: vi.fn().mockResolvedValue({ success: true, data: { snapshot: {}, history: [], summary: {} } }),
   getConfigs: vi.fn().mockResolvedValue([]), getFrontendConfig: vi.fn().mockResolvedValue({ success: true, data: {} }),
   validateConfig: vi.fn().mockResolvedValue({ success: true }), updateConfigs: vi.fn().mockResolvedValue({ success: true, data: { count: 1 } }),
 } }))
+
+function renderWithClient(ui: React.ReactElement) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>)
+}
 
 const status = { rawExists: true, subscriptionExists: true, clashExists: true, mihomoAvailable: true, nodesCount: 12, uptime: 120, version: '1.0.0', mihomoVersion: '1.19.0' }
 const cluster = { totalNodes: 2, onlineNodes: 1, totalProxies: 12, nodes: [
@@ -18,7 +27,7 @@ const cluster = { totalNodes: 2, onlineNodes: 1, totalProxies: 12, nodes: [
 describe('Cluster Dashboard Page', () => {
   it('renders overview counts and readiness without executing business actions', async () => {
     const Dashboard = (await import('@/components/Dashboard')).default
-    render(<MemoryRouter><Dashboard initialCluster={cluster} initialStatus={status} initialError={null} /></MemoryRouter>)
+    renderWithClient(<MemoryRouter><Dashboard initialCluster={cluster} initialStatus={status} initialError={null} /></MemoryRouter>)
     expect(screen.getByRole('heading', { name: '总览' })).toBeDefined()
     expect(screen.getByText('1/2')).toBeDefined()
     expect(screen.getByText('1/4 可用')).toBeDefined()
@@ -28,7 +37,7 @@ describe('Cluster Dashboard Page', () => {
 
   it('shows the expanded workflow shortcuts', async () => {
     const Dashboard = (await import('@/components/Dashboard')).default
-    render(<MemoryRouter><Dashboard initialCluster={null} initialError={null} /></MemoryRouter>)
+    renderWithClient(<MemoryRouter><Dashboard initialCluster={null} initialError={null} /></MemoryRouter>)
     expect(screen.getByRole('link', { name: /添加节点/ })).toBeDefined()
     expect(screen.getByRole('link', { name: /部署运行环境/ })).toBeDefined()
     expect(screen.getByRole('link', { name: /维护订阅状态/ })).toBeDefined()
@@ -36,7 +45,7 @@ describe('Cluster Dashboard Page', () => {
 
   it('manages structured config drafts without runtime capability cards', async () => {
     const ConfigPage = (await import('@/pages/config')).default
-    render(<ConfigPage initialConfigs={['default']} frontendConfig={{}} initialError={null} />)
+    renderWithClient(<ConfigPage initialConfigs={['default']} frontendConfig={{}} initialError={null} />)
     expect(screen.queryByRole('tab', { name: '运行能力' })).toBeNull()
     fireEvent.change(screen.getByLabelText('protocols.sing_box_configs'), { target: { value: 'default, vless-reality' } })
     expect(screen.getByText('字段差异')).toBeDefined()

--- a/packages/frontend/src/components/cluster/__tests__/local-node-display.test.tsx
+++ b/packages/frontend/src/components/cluster/__tests__/local-node-display.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const api = vi.hoisted(() => ({
@@ -36,7 +37,8 @@ describe('Default local node display', () => {
       timestamp: '',
     })
     const { default: NodesPage } = await import('@/pages/nodes')
-    render(<MemoryRouter><NodesPage /></MemoryRouter>)
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    render(<QueryClientProvider client={client}><MemoryRouter><NodesPage /></MemoryRouter></QueryClientProvider>)
     // 本机节点是普通子节点：不被过滤、不带特殊徽标，走与其他节点相同的卡片和操作入口。
     await screen.findByText('本机节点')
     expect(screen.getByText('127.0.0.1 · 本机 · local')).toBeTruthy()

--- a/packages/frontend/src/components/cluster/__tests__/nodes-kernel-edit.test.tsx
+++ b/packages/frontend/src/components/cluster/__tests__/nodes-kernel-edit.test.tsx
@@ -1,7 +1,17 @@
 // @vitest-environment jsdom
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+function renderRuntimes(RuntimesPage: React.ComponentType) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={['/runtimes?node=node-edit']}><RuntimesPage /></MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
 
 const api = vi.hoisted(() => ({
   getClusterStatus: vi.fn(), detectKernels: vi.fn(), updateNodeKernels: vi.fn(), kernelAction: vi.fn(),
@@ -46,7 +56,7 @@ describe('Runtime monitoring management', () => {
 
   it('detects cores and saves monitoring through the dedicated runtime page', async () => {
     const { default: RuntimesPage } = await import('@/pages/runtimes')
-    render(<MemoryRouter initialEntries={['/runtimes?node=node-edit']}><RuntimesPage /></MemoryRouter>)
+    renderRuntimes(RuntimesPage)
     await screen.findByText('1.11.0')
     fireEvent.click(screen.getByRole('button', { name: '编辑监控范围与路径' }))
     expect((screen.getByRole('checkbox', { name: /Xray/ }) as HTMLInputElement).checked).toBe(true)
@@ -61,14 +71,14 @@ describe('Runtime monitoring management', () => {
 
   it('renders the runtime state and real binary path from the component state API', async () => {
     const { default: RuntimesPage } = await import('@/pages/runtimes')
-    render(<MemoryRouter initialEntries={['/runtimes?node=node-edit']}><RuntimesPage /></MemoryRouter>)
+    renderRuntimes(RuntimesPage)
     expect(await screen.findByText('/opt/bin/xray')).toBeDefined()
     expect(screen.getByText('running')).toBeDefined()
   })
 
   it('keeps install-state changes as links to the deployment center', async () => {
     const { default: RuntimesPage } = await import('@/pages/runtimes')
-    render(<MemoryRouter initialEntries={['/runtimes?node=node-edit']}><RuntimesPage /></MemoryRouter>)
+    renderRuntimes(RuntimesPage)
     await screen.findByText('1.11.0')
     const links = screen.getAllByRole('link', { name: /升级\/修复\/卸载|前往部署/ })
     expect(links.some(link => link.getAttribute('href')?.includes('/deploy?node=node-edit'))).toBe(true)

--- a/packages/frontend/src/components/layout/Sidebar.tsx
+++ b/packages/frontend/src/components/layout/Sidebar.tsx
@@ -1,8 +1,8 @@
-import { memo, useEffect, useState } from 'react'
+import { memo } from 'react'
 import { Link, useLocation } from 'react-router-dom'
 import { Icon } from '@iconify/react'
 import ThemeToggle from '@/components/ThemeToggle'
-import { apiService } from '@/lib/api'
+import { useStatus } from '@/lib/queries'
 import { NAV_ITEMS, type NavIcon } from './navigation'
 
 const ICONS: Record<NavIcon, string> = {
@@ -46,19 +46,13 @@ function NavItem({ href, icon, label, active }: { href: string; icon: NavIcon; l
 
 const Sidebar = memo(function Sidebar() {
   const location = useLocation()
-  const [mihomoAvailable, setMihomoAvailable] = useState<boolean | null>(null)
-
-  useEffect(() => {
-    let active = true
-    apiService.getStatus()
-      .then(status => {
-        if (active) setMihomoAvailable(Boolean(status.mihomoAvailable))
-      })
-      .catch(() => {
-        if (active) setMihomoAvailable(false)
-      })
-    return () => { active = false }
-  }, [])
+  // 与 Dashboard 共享 ['status'] key：常驻 Sidebar 与当前页合并为单次请求。
+  const status = useStatus()
+  const mihomoAvailable: boolean | null = status.isPending
+    ? null
+    : status.isError
+      ? false
+      : Boolean(status.data?.mihomoAvailable)
 
   return (
     <aside

--- a/packages/frontend/src/components/shared/QueryBoundary.tsx
+++ b/packages/frontend/src/components/shared/QueryBoundary.tsx
@@ -1,0 +1,33 @@
+import type { UseQueryResult } from '@tanstack/react-query'
+import { Icon } from '@iconify/react'
+import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
+
+interface QueryBoundaryProps<T> {
+  query: Pick<UseQueryResult<T>, 'data' | 'isPending' | 'isError' | 'error' | 'refetch'>
+  skeleton?: React.ReactNode
+  isEmpty?: (data: T) => boolean
+  empty?: React.ReactNode
+  children: (data: T) => React.ReactNode
+}
+
+export function QueryBoundary<T>({ query, skeleton, isEmpty, empty, children }: QueryBoundaryProps<T>) {
+  if (query.isPending) {
+    return <>{skeleton ?? <Skeleton className="h-40 w-full" />}</>
+  }
+  if (query.isError) {
+    const message = query.error instanceof Error ? query.error.message : '加载失败'
+    return (
+      <div className="flex flex-col items-center gap-3 rounded-2xl border border-destructive/30 bg-destructive/5 p-8 text-center">
+        <Icon icon="ph:warning-circle-light" className="size-8 text-destructive" />
+        <p className="text-sm text-destructive">{message}</p>
+        <Button size="sm" variant="outline" onClick={() => { void query.refetch() }}>重试</Button>
+      </div>
+    )
+  }
+  const data = query.data as T
+  if (isEmpty?.(data)) {
+    return <>{empty ?? <p className="py-8 text-center text-sm text-muted-foreground">暂无数据</p>}</>
+  }
+  return <>{children(data)}</>
+}

--- a/packages/frontend/src/components/shared/__tests__/query-boundary.test.tsx
+++ b/packages/frontend/src/components/shared/__tests__/query-boundary.test.tsx
@@ -1,0 +1,31 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { QueryBoundary } from '../QueryBoundary'
+
+const base = { data: undefined, isPending: false, isError: false, error: null, refetch: vi.fn() } as const
+
+describe('QueryBoundary', () => {
+  it('renders skeleton while first load pending', () => {
+    render(<QueryBoundary query={{ ...base, isPending: true }} skeleton={<div>SKELE</div>}>{() => <div>DATA</div>}</QueryBoundary>)
+    expect(screen.getByText('SKELE')).toBeDefined()
+  })
+
+  it('renders error card with retry that calls refetch', () => {
+    const refetch = vi.fn()
+    render(<QueryBoundary query={{ ...base, isError: true, error: new Error('boom'), refetch }}>{() => <div>DATA</div>}</QueryBoundary>)
+    expect(screen.getByText('boom')).toBeDefined()
+    fireEvent.click(screen.getByRole('button', { name: /重试/ }))
+    expect(refetch).toHaveBeenCalledOnce()
+  })
+
+  it('renders empty state when isEmpty true', () => {
+    render(<QueryBoundary query={{ ...base, data: [] }} isEmpty={(d: unknown[]) => d.length === 0} empty={<div>EMPTY</div>}>{() => <div>DATA</div>}</QueryBoundary>)
+    expect(screen.getByText('EMPTY')).toBeDefined()
+  })
+
+  it('renders children on success with data', () => {
+    render(<QueryBoundary query={{ ...base, data: [1] }}>{(d: number[]) => <div>rows:{d.length}</div>}</QueryBoundary>)
+    expect(screen.getByText('rows:1')).toBeDefined()
+  })
+})

--- a/packages/frontend/src/components/ui/skeleton.tsx
+++ b/packages/frontend/src/components/ui/skeleton.tsx
@@ -1,0 +1,5 @@
+import { cn } from '@/lib/utils'
+
+export function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('animate-pulse rounded-md bg-muted', className)} {...props} />
+}

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -74,8 +74,10 @@ function createIdempotencyKey(): string {
 const apiClient = ky.create({
   prefixUrl: API_BASE_URL,
   timeout: 30000,
+  // React Query 统一负责重试（retry: 1）；ky 的 GET 重试若保留会与之叠加，
+  // 让一次失败在 3 轮 ky 重试后才冒泡，拖慢内联错误卡出现。故置 0。
   retry: {
-    limit: 3,
+    limit: 0,
     methods: [...API_RETRY_METHODS],
     statusCodes: [408, 413, 429, 500, 502, 503, 504],
   },

--- a/packages/frontend/src/lib/queries/__tests__/mutations.test.tsx
+++ b/packages/frontend/src/lib/queries/__tests__/mutations.test.tsx
@@ -1,0 +1,21 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { apiService } from '@/lib/api'
+import { queryKeys } from '@/lib/queries'
+import { useUpdateNode } from '@/lib/queries/mutations'
+
+describe('useUpdateNode', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  it('invalidates cluster status after updateNode', async () => {
+    vi.spyOn(apiService, 'updateNode').mockResolvedValue({ success: true, data: {}, timestamp: '' } as never)
+    const client = new QueryClient()
+    const spy = vi.spyOn(client, 'invalidateQueries')
+    const wrapper = ({ children }: { children: React.ReactNode }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    const { result } = renderHook(() => useUpdateNode(), { wrapper })
+    await result.current.mutateAsync({ nodeId: 'n1', patch: { enabled: true } })
+    await waitFor(() => expect(spy).toHaveBeenCalledWith({ queryKey: queryKeys.clusterStatus }))
+  })
+})

--- a/packages/frontend/src/lib/queries/__tests__/queries.test.tsx
+++ b/packages/frontend/src/lib/queries/__tests__/queries.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { apiService } from '@/lib/api'
+import { useClusterStatus } from '@/lib/queries'
+
+describe('useClusterStatus', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  it('dedupes concurrent callers into one apiService call', async () => {
+    const spy = vi.spyOn(apiService, 'getClusterStatus').mockResolvedValue({ success: true, data: { nodes: [] }, timestamp: '' } as never)
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const wrapper = ({ children }: { children: React.ReactNode }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    const a = renderHook(() => useClusterStatus(), { wrapper })
+    const b = renderHook(() => useClusterStatus(), { wrapper })
+    await waitFor(() => expect(a.result.current.data).toBeDefined())
+    await waitFor(() => expect(b.result.current.data).toBeDefined())
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces server error message when success is false', async () => {
+    vi.spyOn(apiService, 'getClusterStatus').mockResolvedValue({ success: false, error: '节点服务不可用', timestamp: '' } as never)
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const wrapper = ({ children }: { children: React.ReactNode }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    const { result } = renderHook(() => useClusterStatus(), { wrapper })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error?.message).toBe('节点服务不可用')
+  })
+})

--- a/packages/frontend/src/lib/queries/index.ts
+++ b/packages/frontend/src/lib/queries/index.ts
@@ -1,0 +1,148 @@
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query'
+import { apiService } from '@/lib/api'
+import { queryKeys } from './keys'
+import type {
+  ArtifactState, ClusterStatus, ComponentDeployStatus, ComponentState,
+  MetricsSnapshot, MetricsSummary, SubscriptionJob, SubscriptionPolicy, SubscriptionPreflight,
+} from '@/lib/types'
+
+// 服务端统一返回 { success, data, error }。data 缺失或 success:false 时抛错，
+// 交给 <QueryBoundary> 渲染内联错误卡（而非静默落空列表）。
+function unwrap<T>(res: { success: boolean; data?: T; error?: unknown }): T {
+  if (!res.success || res.data === undefined) {
+    const reason = res.error
+    const message = typeof reason === 'string' && reason.trim()
+      ? reason
+      : reason && typeof reason === 'object' && typeof (reason as { message?: unknown }).message === 'string'
+        ? (reason as { message: string }).message
+        : '请求失败'
+    throw new Error(message)
+  }
+  return res.data
+}
+
+// 轮询/按需页面通过 options 覆盖 refetchInterval、enabled 等。
+type Extra<T> = Partial<Omit<UseQueryOptions<T, Error, T>, 'queryKey' | 'queryFn'>>
+
+export function useClusterStatus(options?: Extra<ClusterStatus>) {
+  return useQuery({
+    queryKey: queryKeys.clusterStatus,
+    queryFn: async () => unwrap<ClusterStatus>(await apiService.getClusterStatus()),
+    ...options,
+  })
+}
+
+export function useStatus(options?: Extra<Awaited<ReturnType<typeof apiService.getStatus>>>) {
+  return useQuery({
+    queryKey: queryKeys.status,
+    queryFn: () => apiService.getStatus(),
+    ...options,
+  })
+}
+
+type MetricsData = { snapshot: MetricsSnapshot; history: MetricsSnapshot[]; summary: MetricsSummary }
+export function useMetrics(range: '24h' | '7d' | '30d', options?: Extra<MetricsData>) {
+  return useQuery({
+    queryKey: queryKeys.metrics(range),
+    queryFn: async () => {
+      const data = unwrap(await apiService.getMetrics(range))
+      return { snapshot: data.snapshot, history: data.history, summary: data.summary }
+    },
+    ...options,
+  })
+}
+
+export function useComponentStates(nodeIds?: string[], options?: Extra<ComponentState[]>) {
+  return useQuery({
+    queryKey: queryKeys.componentStates(nodeIds),
+    queryFn: async () => unwrap(await apiService.getComponentStates(nodeIds)).states,
+    ...options,
+  })
+}
+
+export function useComponentDeployments(nodeIds?: string[], options?: Extra<Record<string, ComponentDeployStatus>>) {
+  return useQuery({
+    queryKey: queryKeys.componentDeployments(nodeIds),
+    queryFn: async () => unwrap(await apiService.getComponentDeployments(nodeIds)).deployments,
+    ...options,
+  })
+}
+
+export function useSubscriptionJobs(options?: Extra<SubscriptionJob[]>) {
+  return useQuery({
+    queryKey: queryKeys.subscriptionJobs,
+    queryFn: async () => unwrap(await apiService.getSubscriptionJobs()).jobs,
+    ...options,
+  })
+}
+
+export function useSubscriptionPolicy(options?: Extra<SubscriptionPolicy>) {
+  return useQuery({
+    queryKey: queryKeys.subscriptionPolicy,
+    queryFn: async () => unwrap<SubscriptionPolicy>(await apiService.getSubscriptionPolicy()),
+    ...options,
+  })
+}
+
+export function useSubscriptionPreflight(options?: Extra<SubscriptionPreflight>) {
+  return useQuery({
+    queryKey: queryKeys.subscriptionPreflight,
+    queryFn: async () => unwrap<SubscriptionPreflight>(await apiService.preflightSubscription()),
+    ...options,
+  })
+}
+
+export function useArtifacts(options?: Extra<ArtifactState[]>) {
+  return useQuery({
+    queryKey: queryKeys.artifacts,
+    queryFn: async () => unwrap(await apiService.getArtifacts()).artifacts,
+    ...options,
+  })
+}
+
+type SchemaField = { path: string; type: string; restartRequired: boolean; minimum?: number; maximum?: number; allowed?: string[] }
+export function useConfigSchema(options?: Extra<SchemaField[]>) {
+  return useQuery({
+    queryKey: queryKeys.configSchema,
+    queryFn: async () => unwrap(await apiService.getConfigSchema()).fields,
+    ...options,
+  })
+}
+
+type EffectiveConfig = { config: Record<string, unknown>; path: string }
+export function useEffectiveConfig(options?: Extra<EffectiveConfig>) {
+  return useQuery({
+    queryKey: queryKeys.effectiveConfig,
+    queryFn: async () => unwrap<EffectiveConfig>(await apiService.getEffectiveConfig()),
+    ...options,
+  })
+}
+
+type NotificationRecord = { id: string; event: string; ok: boolean; statusCode: number; timestamp: string }
+export function useNotificationHistory(options?: Extra<NotificationRecord[]>) {
+  return useQuery({
+    queryKey: queryKeys.notificationHistory,
+    queryFn: async () => unwrap(await apiService.getNotificationHistory()).records,
+    ...options,
+  })
+}
+
+export function useOpenApi(options?: Extra<unknown>) {
+  return useQuery({
+    queryKey: queryKeys.openApi,
+    queryFn: () => apiService.getOpenApi(),
+    ...options,
+  })
+}
+
+type LogsArgs = Parameters<typeof apiService.getLogs>
+export function useLogs(args: LogsArgs, options?: Extra<Awaited<ReturnType<typeof apiService.getLogs>>['data']>) {
+  return useQuery({
+    queryKey: queryKeys.logs(JSON.stringify(args)),
+    queryFn: async () => unwrap(await apiService.getLogs(...args)),
+    ...options,
+  })
+}
+
+export { queryKeys } from './keys'
+export * from './mutations'

--- a/packages/frontend/src/lib/queries/keys.ts
+++ b/packages/frontend/src/lib/queries/keys.ts
@@ -1,0 +1,16 @@
+export const queryKeys = {
+  clusterStatus: ['cluster-status'] as const,
+  status: ['status'] as const,
+  metrics: (range: string) => ['metrics', range] as const,
+  componentStates: (nodeIds?: string[]) => ['component-states', nodeIds ?? null] as const,
+  componentDeployments: (nodeIds?: string[]) => ['component-deployments', nodeIds ?? null] as const,
+  subscriptionJobs: ['subscription-jobs'] as const,
+  subscriptionPolicy: ['subscription-policy'] as const,
+  subscriptionPreflight: ['subscription-preflight'] as const,
+  artifacts: ['artifacts'] as const,
+  configSchema: ['config-schema'] as const,
+  effectiveConfig: ['effective-config'] as const,
+  notificationHistory: ['notification-history'] as const,
+  openApi: ['openapi'] as const,
+  logs: (key: string) => ['logs', key] as const,
+}

--- a/packages/frontend/src/lib/queries/mutations.ts
+++ b/packages/frontend/src/lib/queries/mutations.ts
@@ -1,9 +1,9 @@
-import { useMutation, useQueryClient, type QueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient, type QueryClient, type QueryKey } from '@tanstack/react-query'
 import { apiService } from '@/lib/api'
 import type { DeployComponent, DeployOperation, KernelType, NodeKernelConfig, SubscriptionPolicy } from '@/lib/types'
 import { queryKeys } from './keys'
 
-function invalidate(qc: QueryClient, keys: readonly unknown[][]) {
+function invalidate(qc: QueryClient, keys: readonly QueryKey[]) {
   for (const queryKey of keys) void qc.invalidateQueries({ queryKey })
 }
 

--- a/packages/frontend/src/lib/queries/mutations.ts
+++ b/packages/frontend/src/lib/queries/mutations.ts
@@ -1,0 +1,161 @@
+import { useMutation, useQueryClient, type QueryClient } from '@tanstack/react-query'
+import { apiService } from '@/lib/api'
+import type { DeployComponent, DeployOperation, KernelType, NodeKernelConfig, SubscriptionPolicy } from '@/lib/types'
+import { queryKeys } from './keys'
+
+function invalidate(qc: QueryClient, keys: readonly unknown[][]) {
+  for (const queryKey of keys) void qc.invalidateQueries({ queryKey })
+}
+
+// ---- Node writes → cluster status ----
+export function useUpdateNode() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (vars: { nodeId: string; patch: Parameters<typeof apiService.updateNode>[1] }) =>
+      apiService.updateNode(vars.nodeId, vars.patch),
+    onSuccess: () => invalidate(qc, [queryKeys.clusterStatus]),
+  })
+}
+
+export function useDeleteNode() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (vars: { nodeId: string; force?: boolean }) => apiService.deleteNode(vars.nodeId, vars.force),
+    onSuccess: () => invalidate(qc, [queryKeys.clusterStatus]),
+  })
+}
+
+export function useAddNode() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (data: Parameters<typeof apiService.addNode>[0]) => apiService.addNode(data),
+    onSuccess: () => invalidate(qc, [queryKeys.clusterStatus]),
+  })
+}
+
+export function useUpdateNodeKernels() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (vars: { nodeId: string; kernels: NodeKernelConfig[] }) =>
+      apiService.updateNodeKernels(vars.nodeId, vars.kernels),
+    onSuccess: () => invalidate(qc, [queryKeys.clusterStatus, queryKeys.componentStates()]),
+  })
+}
+
+// ---- Agent actions → cluster status ----
+export function useAgentAction() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (vars: { nodeId: string; action: 'start' | 'stop' | 'restart' }) =>
+      vars.action === 'start' ? apiService.startAgent(vars.nodeId)
+        : vars.action === 'stop' ? apiService.stopAgent(vars.nodeId)
+          : apiService.restartAgent(vars.nodeId),
+    onSuccess: () => invalidate(qc, [queryKeys.clusterStatus]),
+  })
+}
+
+export function useClusterHealthCheck() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (nodeId?: string) => apiService.clusterHealthCheck(nodeId),
+    onSuccess: () => invalidate(qc, [queryKeys.clusterStatus]),
+  })
+}
+
+// ---- Kernel → component states + cluster ----
+export function useKernelAction() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (vars: { nodeId: string; kernelType: KernelType; action: 'start' | 'stop' | 'restart' }) =>
+      apiService.kernelAction(vars.nodeId, vars.kernelType, vars.action),
+    onSuccess: () => invalidate(qc, [queryKeys.componentStates(), queryKeys.clusterStatus]),
+  })
+}
+
+// ---- Deploy → deployments + component states ----
+export function useStartDeployment() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (vars: {
+      nodeId: string; component: DeployComponent; operation: DeployOperation
+      options?: { preserveConfig: boolean; preserveData: boolean }
+    }) => apiService.startComponentDeployment(vars.nodeId, vars.component, vars.operation, vars.options),
+    onSuccess: () => invalidate(qc, [queryKeys.componentDeployments(), queryKeys.componentStates()]),
+  })
+}
+
+export function useRetryDeployment() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (taskId: string) => apiService.retryComponentDeployment(taskId),
+    onSuccess: () => invalidate(qc, [queryKeys.componentDeployments()]),
+  })
+}
+
+export function useCancelDeployment() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (taskId: string) => apiService.cancelComponentDeployment(taskId),
+    onSuccess: () => invalidate(qc, [queryKeys.componentDeployments()]),
+  })
+}
+
+// ---- Subscription ----
+export function useStartSubscriptionJob() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: () => apiService.startSubscriptionJob(),
+    onSuccess: () => invalidate(qc, [queryKeys.subscriptionJobs]),
+  })
+}
+
+export function useRetrySubscriptionJob() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (jobId: string) => apiService.retrySubscriptionJob(jobId),
+    onSuccess: () => invalidate(qc, [queryKeys.subscriptionJobs]),
+  })
+}
+
+export function useUpdateSubscriptionPolicy() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (policy: SubscriptionPolicy) => apiService.updateSubscriptionPolicy(policy),
+    onSuccess: () => invalidate(qc, [queryKeys.subscriptionPolicy]),
+  })
+}
+
+// ---- Config ----
+export function usePatchConfigValues() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (changes: Array<{ path: string; value: unknown }>) => apiService.patchConfigValues(changes),
+    onSuccess: () => invalidate(qc, [queryKeys.effectiveConfig]),
+  })
+}
+
+export function useRestoreConfig() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: () => apiService.restoreConfig(),
+    onSuccess: () => invalidate(qc, [queryKeys.effectiveConfig]),
+  })
+}
+
+// ---- Outputs ----
+export function useValidateArtifacts() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (name?: Parameters<typeof apiService.validateArtifacts>[0]) => apiService.validateArtifacts(name),
+    onSuccess: () => invalidate(qc, [queryKeys.artifacts]),
+  })
+}
+
+// ---- Subscription update (actions page) ----
+export function useUpdateSubscription() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: () => apiService.updateSubscription(),
+    onSuccess: () => invalidate(qc, [queryKeys.status, queryKeys.clusterStatus]),
+  })
+}

--- a/packages/frontend/src/lib/queryClient.ts
+++ b/packages/frontend/src/lib/queryClient.ts
@@ -1,0 +1,27 @@
+import { QueryClient, QueryCache } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+// 后台刷新失败（该 query 已有缓存数据显示在屏上）弹 toast 提示。首次加载失败
+// 由 <QueryBoundary> 渲染内联错误卡，因此这里必须跳过（data === undefined），
+// 否则同一次失败会既弹 toast 又显示错误卡。
+export function makeQueryClient(): QueryClient {
+  return new QueryClient({
+    queryCache: new QueryCache({
+      onError: (error, query) => {
+        if (query.state.data === undefined) return
+        const message = error instanceof Error ? error.message : '后台刷新失败'
+        toast.error('数据刷新失败', { description: message })
+      },
+    }),
+    defaultOptions: {
+      queries: {
+        staleTime: 30_000,
+        gcTime: 300_000,
+        retry: 1,
+        refetchOnWindowFocus: false,
+      },
+    },
+  })
+}
+
+export const queryClient = makeQueryClient()

--- a/packages/frontend/src/pages/actions.tsx
+++ b/packages/frontend/src/pages/actions.tsx
@@ -1,6 +1,7 @@
 import { Icon } from '@iconify/react'
 import { useCallback, useState } from 'react'
 import { apiService } from '@/lib/api'
+import { useUpdateSubscription } from '@/lib/queries'
 import { useAppContext } from '@/context/AppContext'
 import { Button } from '@/components/ui/button'
 import SectionHeading from '@/components/shared/SectionHeading'
@@ -13,22 +14,19 @@ const FILES = [
 
 export default function ActionsPage() {
   const { updateResult, setUpdateResult, openConvertModal } = useAppContext()
-  const [updating, setUpdating] = useState(false)
+  const updateSubscription = useUpdateSubscription()
+  const updating = updateSubscription.isPending
   const [updateError, setUpdateError] = useState<string | null>(null)
 
   const handleUpdate = useCallback(async () => {
-    setUpdating(true)
     setUpdateResult(null)
     setUpdateError(null)
     try {
-      const result = await apiService.updateSubscription()
-      setUpdateResult(result)
+      setUpdateResult(await updateSubscription.mutateAsync())
     } catch (err) {
       setUpdateError(err instanceof Error ? err.message : '更新失败')
-    } finally {
-      setUpdating(false)
     }
-  }, [setUpdateResult])
+  }, [setUpdateResult, updateSubscription])
 
   const handleDownload = (filename: string) => {
     window.open(apiService.getDownloadUrl(filename), '_blank')

--- a/packages/frontend/src/pages/agents.tsx
+++ b/packages/frontend/src/pages/agents.tsx
@@ -1,9 +1,11 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { Icon } from '@iconify/react'
 import { Link, useSearchParams } from 'react-router-dom'
 import { toast } from 'sonner'
-import { apiService } from '@/lib/api'
-import type { ClusterStatus, NodeStatus } from '@/lib/types'
+import type { NodeStatus } from '@/lib/types'
+import { useAgentAction, useClusterHealthCheck, useClusterStatus } from '@/lib/queries'
+import { QueryBoundary } from '@/components/shared/QueryBoundary'
+import { Skeleton } from '@/components/ui/skeleton'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -21,40 +23,38 @@ function statusLabel(node: NodeStatus) {
 export default function AgentsPage() {
   const [searchParams] = useSearchParams()
   const focusNode = searchParams.get('node')
-  const [cluster, setCluster] = useState<ClusterStatus | null>(null)
+  const clusterQuery = useClusterStatus()
+  const cluster = clusterQuery.data ?? null
+  const agentAction = useAgentAction()
+  const healthCheck = useClusterHealthCheck()
   const [busy, setBusy] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
 
-  const refresh = useCallback(async () => {
-    const result = await apiService.getClusterStatus()
-    if (result.success) setCluster(result.data as ClusterStatus)
-  }, [])
-
-  useEffect(() => { refresh().catch(caught => setError(caught instanceof Error ? caught.message : 'Agent 状态加载失败')) }, [refresh])
+  const refresh = useCallback(() => { void clusterQuery.refetch() }, [clusterQuery])
   const nodes = useMemo(() => [...(cluster?.nodes || [])].sort((a, b) => Number(b.nodeId === focusNode) - Number(a.nodeId === focusNode)), [cluster?.nodes, focusNode])
 
   const run = useCallback(async (node: NodeStatus, action: 'start' | 'stop' | 'restart' | 'health') => {
     setBusy(`${node.nodeId}:${action}`)
     setError(null)
     try {
-      const response = action === 'start' ? await apiService.startAgent(node.nodeId)
-        : action === 'stop' ? await apiService.stopAgent(node.nodeId)
-        : action === 'restart' ? await apiService.restartAgent(node.nodeId)
-        : await apiService.clusterHealthCheck(node.nodeId)
+      // 写操作的 mutation 成功后会失效 cluster-status，自动刷新，无需手动 refresh。
+      const response = action === 'health'
+        ? await healthCheck.mutateAsync(node.nodeId)
+        : await agentAction.mutateAsync({ nodeId: node.nodeId, action })
       if (!response.success) throw new Error(response.error || `${action} 失败`)
       toast.success(action === 'health' ? '健康检查完成' : 'Agent 维护操作完成', { description: node.name })
-      await refresh()
     } catch (caught) {
       const message = caught instanceof Error ? caught.message : 'Agent 操作失败'
       setError(message)
       toast.error('Agent 操作失败', { description: message })
     } finally { setBusy(null) }
-  }, [refresh])
+  }, [agentAction, healthCheck])
 
   return (
     <SignalPage crumb="Agent lifecycle" title="Agent 维护" description="维护已安装监控程序的运行生命周期；安装态变更统一前往部署中心。" status={`${nodes.filter(node => node.agent?.status === 'running').length}/${nodes.length} 运行中`} maxWidth="narrow" actions={<Button variant="outline" onClick={refresh}><Icon icon="ph:arrow-clockwise-light" />刷新</Button>}>
       {error ? <Alert variant="destructive"><AlertTitle>Agent 操作失败</AlertTitle><AlertDescription>{error}</AlertDescription></Alert> : null}
-      <div className="grid gap-5 lg:grid-cols-2">
+      <QueryBoundary query={clusterQuery} skeleton={<div className="grid gap-5 lg:grid-cols-2">{Array.from({ length: 2 }).map((_, i) => <Skeleton key={i} className="h-64 w-full rounded-xl" />)}</div>}>
+      {() => <div className="grid gap-5 lg:grid-cols-2">
         {nodes.map(node => {
           const deployed = Boolean(node.agent?.deployed)
           const running = node.agent?.status === 'running'
@@ -89,7 +89,8 @@ export default function AgentsPage() {
           )
         })}
         {nodes.length === 0 ? <Card><CardContent className="p-10 text-center text-muted-foreground">暂无节点。请先在节点页创建节点档案。</CardContent></Card> : null}
-      </div>
+      </div>}
+      </QueryBoundary>
     </SignalPage>
   )
 }

--- a/packages/frontend/src/pages/api-docs.tsx
+++ b/packages/frontend/src/pages/api-docs.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Icon } from '@iconify/react'
 import { toast } from 'sonner'
-import { apiService } from '@/lib/api'
+import { useOpenApi } from '@/lib/queries'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -69,28 +69,18 @@ function curlFor(endpoint: ApiEndpoint, serverUrl?: string) {
 }
 
 export default function ApiDocsPage() {
-  const [document, setDocument] = useState<OpenApiDocument | null>(null)
   const [open, setOpen] = useState<string | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const openApiQuery = useOpenApi()
+  const load = () => { void openApiQuery.refetch() }
+  const loading = openApiQuery.isPending
 
-  const load = useCallback(async () => {
-    setLoading(true)
-    setError(null)
-    try {
-      const result = await apiService.getOpenApi() as OpenApiDocument | { success?: boolean; error?: string }
-      if (!result || typeof result !== 'object' || !('paths' in result) || !result.paths) {
-        throw new Error('服务端未返回有效的 OpenAPI 文档')
-      }
-      setDocument(result as OpenApiDocument)
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : 'OpenAPI 文档加载失败')
-    } finally {
-      setLoading(false)
-    }
-  }, [])
-
-  useEffect(() => { void load() }, [load])
+  const raw = openApiQuery.data
+  const document = raw && typeof raw === 'object' && 'paths' in raw && (raw as OpenApiDocument).paths
+    ? raw as OpenApiDocument
+    : null
+  const error = openApiQuery.error
+    ? (openApiQuery.error.message || 'OpenAPI 文档加载失败')
+    : (!loading && raw && !document ? '服务端未返回有效的 OpenAPI 文档' : null)
 
   const endpoints = useMemo(() => document ? readOpenApiEndpoints(document) : [], [document])
   const groups = useMemo(() => {

--- a/packages/frontend/src/pages/config.tsx
+++ b/packages/frontend/src/pages/config.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { Icon } from '@iconify/react'
 import { toast } from 'sonner'
 import { apiService } from '@/lib/api'
+import { queryKeys, useConfigSchema, useEffectiveConfig, usePatchConfigValues, useRestoreConfig } from '@/lib/queries'
 import type { FrontendConfig } from '@/lib/configApi'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
@@ -89,25 +91,35 @@ export default function ConfigPage({ initialConfigs, frontendConfig, initialErro
   const [saving, setSaving] = useState(false)
   const [restartPending, setRestartPending] = useState(false)
   const [notificationHistory, setNotificationHistory] = useState<Array<{ id: string; event: string; ok: boolean; statusCode: number; timestamp: string }>>([])
+  const queryClient = useQueryClient()
+  const live = initialConfigs === undefined
+  const schemaQuery = useConfigSchema({ enabled: live })
+  const effectiveQuery = useEffectiveConfig({ enabled: live })
+  const patchConfig = usePatchConfigValues()
+  const restoreConfigMutation = useRestoreConfig()
 
   const applyLoaded = useCallback((fields: FieldDefinition[], config: Record<string, unknown>, path: string) => {
     setSchema(fields); setEffective(config); setInitial(structuredClone(config)); setConfigPath(path)
     setDraft(Object.fromEntries(fields.map(field => [field.path, inputValue(valueAt(config, field.path), field.type)])))
   }, [])
 
-  const refresh = useCallback(async () => {
-    const [schemaResponse, configResponse] = await Promise.all([apiService.getConfigSchema(), apiService.getEffectiveConfig()])
-    if (!schemaResponse.success || !schemaResponse.data || !configResponse.success || !configResponse.data) throw new Error('配置 schema 或生效值加载失败')
-    applyLoaded(schemaResponse.data.fields as FieldDefinition[], configResponse.data.config, configResponse.data.path)
-  }, [applyLoaded])
+  // schema 与生效值就绪后一次性播种草稿。保存/恢复失效缓存触发 refetch → 新数据引用 →
+  // 本 effect 重跑，等价于旧版保存后 await refresh() 的重置行为。
+  useEffect(() => {
+    if (!live || !schemaQuery.data || !effectiveQuery.data) return
+    applyLoaded(schemaQuery.data as FieldDefinition[], effectiveQuery.data.config, effectiveQuery.data.path)
+  }, [live, schemaQuery.data, effectiveQuery.data, applyLoaded])
 
   useEffect(() => {
-    if (initialConfigs !== undefined) {
-      setDraft({ 'protocols.sing_box_configs': initialConfigs.join(', ') })
-      return
-    }
-    refresh().catch(caught => setError(caught instanceof Error ? caught.message : '配置加载失败'))
-  }, [initialConfigs, refresh])
+    if (initialConfigs !== undefined) setDraft({ 'protocols.sing_box_configs': initialConfigs.join(', ') })
+  }, [initialConfigs])
+
+  const refresh = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: queryKeys.configSchema })
+    void queryClient.invalidateQueries({ queryKey: queryKeys.effectiveConfig })
+  }, [queryClient])
+
+  const loadError = live ? (schemaQuery.error ?? effectiveQuery.error)?.message ?? null : null
 
   const changes = useMemo(() => schema.flatMap(field => {
     const next = field.type === 'boolean' ? draft[field.path] === 'true' : parseInput(draft[field.path] ?? '', field)
@@ -137,25 +149,25 @@ export default function ConfigPage({ initialConfigs, frontendConfig, initialErro
     if (!changes.length) return
     setSaving(true); setError(null); setMessage(null)
     try {
-      const response = await apiService.patchConfigValues(changes.map(({ path, after }) => ({ path, value: after })))
+      const response = await patchConfig.mutateAsync(changes.map(({ path, after }) => ({ path, value: after })))
       if (!response.success || !response.data) throw new Error(displayError(response.error, '配置保存失败'))
       setRestartPending(response.data.restartRequired)
       setMessage(`已在一次原子替换中保存 ${changes.length} 个字段${response.data.restartRequired ? '；部分字段需要重启 Dashboard 后生效' : '并生效'}`)
       toast.success('配置已原子保存')
-      if (initialConfigs === undefined) await refresh()
+      // mutation 失效 effective-config，effect 会用新数据重置草稿。
     } catch (caught) { setError(caught instanceof Error ? caught.message : '配置保存失败') }
     finally { setSaving(false) }
-  }, [changes, initialConfigs, refresh])
+  }, [changes, patchConfig])
 
   const restore = async () => {
     if (!window.confirm('恢复到上一次成功配置？当前配置会保留为 pre-restore 备份。')) return
     setError(null)
     // apiService 在 HTTP 失败时抛出 ApiError；不捕获的话页面停在原状，用户看不到失败。
     try {
-      const response = await apiService.restoreConfig()
+      const response = await restoreConfigMutation.mutateAsync()
       if (!response.success) throw new Error(displayError(response.error, '配置恢复失败'))
       toast.success('已恢复 last-good 配置')
-      await refresh()
+      // mutation 失效 effective-config，effect 会用新数据重置草稿。
     } catch (caught) { setError(caught instanceof Error ? caught.message : '配置恢复失败') }
   }
 
@@ -189,7 +201,7 @@ export default function ConfigPage({ initialConfigs, frontendConfig, initialErro
   }
 
   return <SignalPage crumb="Configuration workspace" title="配置" description="由 Core schema 驱动草稿、字段差异、完整校验、单次原子保存、待重启反馈、恢复和导入预览。" status={dirty ? `${changes.length} 个待保存字段` : restartPending ? '配置已保存，等待重启' : '草稿与生效值一致'} maxWidth="narrow" actions={<><Button variant="outline" onClick={validate}><Icon icon="ph:shield-check-light" />校验草稿</Button><Button variant="outline" onClick={refresh} disabled={initialConfigs !== undefined}><Icon icon="ph:arrow-clockwise-light" />刷新</Button></>}>
-    {error ? <Alert variant="destructive"><AlertTitle>配置操作失败</AlertTitle><AlertDescription>{error}</AlertDescription></Alert> : null}
+    {(error ?? loadError) ? <Alert variant="destructive"><AlertTitle>配置操作失败</AlertTitle><AlertDescription>{error ?? loadError}</AlertDescription></Alert> : null}
     {message ? <Alert variant="success"><AlertTitle>配置结果</AlertTitle><AlertDescription>{message}</AlertDescription></Alert> : null}
     {restartPending ? <Alert><AlertTitle>存在待重启字段</AlertTitle><AlertDescription>文件已经安全保存，但相关进程需要重启后才会读取新路径或端口。</AlertDescription></Alert> : null}
     <div className="grid gap-5 md:grid-cols-3"><Card variant="elevated"><CardHeader><CardDescription>Schema 字段</CardDescription><CardTitle className="signal-value">{schema.length}</CardTitle></CardHeader></Card><Card variant="elevated"><CardHeader><CardDescription>待保存差异</CardDescription><CardTitle className="signal-value">{changes.length}</CardTitle></CardHeader></Card><Card variant="elevated"><CardHeader><CardDescription>配置路径</CardDescription><CardTitle className="break-all text-sm">{configPath || '测试初始值'}</CardTitle></CardHeader></Card></div>

--- a/packages/frontend/src/pages/deploy.tsx
+++ b/packages/frontend/src/pages/deploy.tsx
@@ -1,10 +1,17 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { Icon } from '@iconify/react'
 import { Link, useSearchParams } from 'react-router-dom'
 import { toast } from 'sonner'
 import { apiService } from '@/lib/api'
 import { streamServerEvents } from '@/lib/sse'
-import type { ClusterStatus, ComponentDeployStatus, ComponentState, DeployComponent, DeployOperation, NodeStatus } from '@/lib/types'
+import {
+  queryKeys, useClusterStatus, useClusterHealthCheck, useComponentDeployments, useComponentStates,
+  useCancelDeployment, useRetryDeployment, useStartDeployment,
+} from '@/lib/queries'
+import type { ComponentDeployStatus, DeployComponent, DeployOperation, NodeStatus } from '@/lib/types'
+import { QueryBoundary } from '@/components/shared/QueryBoundary'
+import { Skeleton } from '@/components/ui/skeleton'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -87,9 +94,19 @@ export default function DeployPage() {
   const [searchParams] = useSearchParams()
   const requestedComponent = searchParams.get('component') as DeployComponent | null
   const requestedOperation = searchParams.get('operation') as DeployOperation | null
-  const [cluster, setCluster] = useState<ClusterStatus | null>(null)
-  const [tasks, setTasks] = useState<Record<string, ComponentDeployStatus>>({})
-  const [states, setStates] = useState<ComponentState[]>([])
+  const queryClient = useQueryClient()
+  // SSE 实时更新，轮询 4s 兜底；tab 隐藏时暂停轮询以省请求。
+  const pollOptions = { refetchInterval: 4000, refetchIntervalInBackground: false } as const
+  const clusterQuery = useClusterStatus(pollOptions)
+  const deploymentsQuery = useComponentDeployments(undefined, pollOptions)
+  const statesQuery = useComponentStates(undefined, pollOptions)
+  const cluster = clusterQuery.data ?? null
+  const tasks = deploymentsQuery.data ?? {}
+  const states = statesQuery.data ?? []
+  const startDeployment = useStartDeployment()
+  const retryDeployment = useRetryDeployment()
+  const cancelDeployment = useCancelDeployment()
+  const healthCheck = useClusterHealthCheck()
   const [selectedNode, setSelectedNode] = useState(searchParams.get('node') || '')
   const [component, setComponent] = useState<DeployComponent>(COMPONENTS.some(item => item.value === requestedComponent) ? requestedComponent! : 'agent')
   const [operation, setOperation] = useState<DeployOperation>(OPERATIONS.some(item => item.value === requestedOperation) ? requestedOperation! : 'install')
@@ -115,20 +132,14 @@ export default function DeployPage() {
     })
   }, [])
 
+  // queryClient 身份稳定，refresh 因此稳定：SSE 副作用不会因刷新回调变化而反复重连。
   const refresh = useCallback(async () => {
-    const [clusterResult, taskResult, stateResult] = await Promise.all([
-      apiService.getClusterStatus(), apiService.getComponentDeployments(), apiService.getComponentStates(),
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: queryKeys.clusterStatus }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.componentDeployments() }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.componentStates() }),
     ])
-    if (clusterResult.success) setCluster(clusterResult.data as ClusterStatus)
-    if (taskResult.success && taskResult.data) setTasks(taskResult.data.deployments)
-    if (stateResult.success && stateResult.data) setStates(stateResult.data.states)
-  }, [])
-
-  useEffect(() => {
-    refresh().catch(caught => setError(caught instanceof Error ? caught.message : '部署状态加载失败'))
-    const timer = window.setInterval(() => refresh().catch(() => {}), 4000)
-    return () => window.clearInterval(timer)
-  }, [refresh])
+  }, [queryClient])
 
   const nodes = useMemo(() => cluster?.nodes || [], [cluster?.nodes])
   const taskList = useMemo(() => Object.values(tasks).sort((a, b) => b.startedAt - a.startedAt), [tasks])
@@ -187,53 +198,51 @@ export default function DeployPage() {
     setSubmitting(true)
     setError(null)
     try {
-      const response = await apiService.startComponentDeployment(selectedNode, component, operation, { preserveConfig, preserveData })
+      const response = await startDeployment.mutateAsync({ nodeId: selectedNode, component, operation, options: { preserveConfig, preserveData } })
       if (!response.success) throw new Error(errorMessage(response.error, '创建部署任务失败'))
       toast.success('部署任务已进入队列', { description: `${node?.name || selectedNode} · ${component}` })
-      await refresh()
     } catch (caught) {
       const message = caught instanceof Error ? caught.message : '创建部署任务失败'
       setError(message)
       toast.error('部署任务创建失败', { description: message })
     } finally { setSubmitting(false) }
-  }, [blockedNodes, component, node?.name, operation, preserveConfig, preserveData, refresh, selectedNode])
+  }, [blockedNodes, component, node?.name, operation, preserveConfig, preserveData, startDeployment, selectedNode])
 
   // apiService 在 HTTP 失败时抛出 ApiError；不捕获的话异常逃逸，用户得不到任何反馈。
   const retry = useCallback(async (task: ComponentDeployStatus) => {
     try {
-      const response = await apiService.retryComponentDeployment(task.taskId)
+      const response = await retryDeployment.mutateAsync(task.taskId)
       if (!response.success) throw new Error(errorMessage(response.error, '无法重试该任务'))
       toast.success('已按原始输入创建重试任务')
-      await refresh()
     } catch (caught) {
       const message = caught instanceof Error ? caught.message : '无法重试该任务'
       setError(message)
       toast.error('重试失败', { description: message })
     }
-  }, [refresh])
+  }, [retryDeployment])
 
   const cancel = useCallback(async (task: ComponentDeployStatus) => {
     try {
-      const response = await apiService.cancelComponentDeployment(task.taskId)
+      const response = await cancelDeployment.mutateAsync(task.taskId)
       if (!response.success) throw new Error(errorMessage(response.error, '任务已进入不可取消阶段'))
       toast.success('任务已取消')
-      await refresh()
     } catch (caught) {
       const message = caught instanceof Error ? caught.message : '任务已进入不可取消阶段'
       setError(message)
       toast.error('取消失败', { description: message })
     }
-  }, [refresh])
+  }, [cancelDeployment])
 
   // 「检查健康」必须真的探测目标节点：只刷新聚合状态无法证明刚装好的 Agent 已经起来了。
   const completeManual = useCallback(async () => {
     if (selectedNode) {
-      const response = await apiService.clusterHealthCheck(selectedNode)
+      const response = await healthCheck.mutateAsync(selectedNode)
       if (!response.success) toast.error('节点健康检查失败', { description: errorMessage(response.error, '目标节点尚未响应健康检查') })
       else toast.success('已完成目标节点健康检查', { description: node?.name || selectedNode })
+    } else {
+      await refresh()
     }
-    await refresh()
-  }, [node?.name, refresh, selectedNode])
+  }, [healthCheck, node?.name, refresh, selectedNode])
 
   const sshTarget = `${node?.sshUser || '<ssh-user>'}@${node?.host || '<child-host>'}`
   const installer = `curl -fsSL https://github.com/imal1/miobridge/releases/latest/download/install-agent.sh -o /tmp/install-agent.sh\nsh /tmp/install-agent.sh --config /tmp/miobridge-agent.yaml`
@@ -276,12 +285,16 @@ export default function DeployPage() {
       <Card className="mt-5">
         <CardHeader><CardDescription>3 / 3 · SSE 实时更新，轮询自动降级</CardDescription><CardTitle>任务与恢复</CardTitle></CardHeader>
         <CardContent className="space-y-3">
+          <QueryBoundary query={deploymentsQuery} skeleton={<div className="space-y-3">{Array.from({ length: 2 }).map((_, i) => <Skeleton key={i} className="h-28 w-full rounded-[20px]" />)}</div>}>
+          {() => <>
           {taskList.map(task => {
             const taskNode = nodes.find(item => item.nodeId === task.nodeId)
             const cancellable = task.status === 'pending' || (task.status === 'running' && task.step === 'prechecking')
             return <article key={task.taskId} className="rounded-[20px] border border-[var(--border)] bg-[var(--surface-container)] p-4"><div className="flex flex-wrap items-start justify-between gap-3"><div><p className="font-medium">{taskNode?.name || task.nodeId} · {task.component}</p><p className="text-xs text-muted-foreground">{task.operation} · {STEP_LABELS[task.step] || task.step} · {new Date(task.startedAt).toLocaleString('zh-CN')}</p>{task.beforeVersion || task.afterVersion ? <p className="mt-1 text-xs text-muted-foreground">版本 {task.beforeVersion || '未知'} → {task.afterVersion || '待确认'}</p> : null}</div>{taskBadge(task)}</div><Progress className="mt-4" value={task.progress} /><div className="mt-2 flex flex-wrap items-center justify-between gap-3 text-sm"><span className={task.status === 'error' ? 'text-destructive' : 'text-muted-foreground'}>{task.message}</span><div className="flex flex-wrap gap-2">{cancellable ? <Button size="sm" variant="outline" onClick={() => cancel(task)}>取消任务</Button> : null}{task.status === 'error' || task.status === 'cancelled' ? <Button size="sm" variant="outline" onClick={() => retry(task)}>按原输入重试</Button> : null}<Button asChild size="sm" variant="outline"><Link to={`/logs?node=${encodeURIComponent(task.nodeId)}&task=${encodeURIComponent(task.taskId)}`}>查看日志</Link></Button></div></div></article>
           })}
           {taskList.length === 0 ? <div className="rounded-[20px] bg-[var(--surface-container)] p-8 text-center text-muted-foreground">暂无部署任务。任务创建后会持久化，并在刷新或服务重启后恢复显示。</div> : null}
+          </>}
+          </QueryBoundary>
 
           {latestEvents.length ? (
             <section aria-label="部署任务事件" className="rounded-[20px] border border-[var(--border)] bg-[var(--surface-container-low)] p-4">

--- a/packages/frontend/src/pages/logs.tsx
+++ b/packages/frontend/src/pages/logs.tsx
@@ -3,7 +3,8 @@ import { Icon } from '@iconify/react'
 import { useSearchParams } from 'react-router-dom'
 import { toast } from 'sonner'
 import { apiService, type LogsResult } from '@/lib/api'
-import type { ClusterStatus, NodeStatus } from '@/lib/types'
+import { useClusterStatus } from '@/lib/queries'
+import type { NodeStatus } from '@/lib/types'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -137,7 +138,9 @@ function LogFilters(props: FiltersProps) {
 export default function LogsPage() {
   const [searchParams] = useSearchParams()
   const [logs, setLogs] = useState<LogsResult | null>(null)
-  const [nodes, setNodes] = useState<NodeStatus[]>([])
+  // 节点列表与 Sidebar/其他页共享 cluster-status，合并为单请求。
+  const clusterQuery = useClusterStatus()
+  const nodes = clusterQuery.data?.nodes ?? []
   const [source, setSourceState] = useState<LogSource>(() => initialLogSource(searchParams))
   const [nodeId, setNodeId] = useState(searchParams.get('node') || '')
   const [file, setFile] = useState('')
@@ -191,13 +194,8 @@ export default function LogsPage() {
   }, [component, file, from, level, nodeId, query, source, taskId, to])
 
   useEffect(() => {
-    apiService.getClusterStatus().then(result => {
-      if (!result.success) return
-      const availableNodes = (result.data as ClusterStatus).nodes || []
-      setNodes(availableNodes)
-      if (!nodeId && availableNodes[0]) setNodeId(availableNodes[0].nodeId)
-    }).catch(() => {})
-  }, [])
+    if (!nodeId && nodes[0]) setNodeId(nodes[0].nodeId)
+  }, [nodes, nodeId])
 
   useEffect(() => {
     if (initialLoad.current) return
@@ -207,7 +205,8 @@ export default function LogsPage() {
 
   useEffect(() => {
     if (!autoRefresh) return
-    const timer = window.setInterval(() => { void loadLogs(false) }, 5000)
+    // tab 隐藏时暂停轮询，回到前台再继续，避免后台白耗请求。
+    const timer = window.setInterval(() => { if (document.visibilityState === 'visible') void loadLogs(false) }, 5000)
     return () => window.clearInterval(timer)
   }, [autoRefresh, loadLogs])
 

--- a/packages/frontend/src/pages/nodes.tsx
+++ b/packages/frontend/src/pages/nodes.tsx
@@ -1,10 +1,12 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { Icon } from '@iconify/react'
 import { Link, useSearchParams } from 'react-router-dom'
 import { toast } from 'sonner'
-import { apiService } from '@/lib/api'
-import type { ClusterStatus, NodeStatus, SshAuthMethod } from '@/lib/types'
+import type { NodeStatus, SshAuthMethod } from '@/lib/types'
+import { useClusterStatus, useDeleteNode, useUpdateNode } from '@/lib/queries'
 import { AddNodeForm } from '@/components/cluster/AddNodeForm'
+import { QueryBoundary } from '@/components/shared/QueryBoundary'
+import { Skeleton } from '@/components/ui/skeleton'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -19,7 +21,10 @@ type Filter = 'all' | 'enabled' | 'disabled' | 'undeployed'
 
 export default function NodesPage() {
   const [params, setParams] = useSearchParams()
-  const [cluster, setCluster] = useState<ClusterStatus | null>(null)
+  const clusterQuery = useClusterStatus()
+  const cluster = clusterQuery.data ?? null
+  const updateNode = useUpdateNode()
+  const deleteNode = useDeleteNode()
   const [addOpen, setAddOpen] = useState(params.get('intent') === 'add')
   const [editing, setEditing] = useState<NodeStatus | null>(null)
   const [draft, setDraft] = useState({
@@ -31,11 +36,7 @@ export default function NodesPage() {
   const [busy, setBusy] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
 
-  const refresh = useCallback(async () => {
-    const result = await apiService.getClusterStatus()
-    if (result.success) setCluster(result.data as ClusterStatus)
-  }, [])
-  useEffect(() => { refresh().catch(caught => setError(caught instanceof Error ? caught.message : '节点加载失败')) }, [refresh])
+  const refresh = useCallback(async () => { await clusterQuery.refetch() }, [clusterQuery])
 
   const nodes = useMemo(() => (cluster?.nodes || []).filter(node => {
     if (filter === 'enabled' && node.enabled === false) return false
@@ -70,19 +71,22 @@ export default function NodesPage() {
     try {
       const { sshPort, sshAuthMethod, sshCredential, ...rest } = draft
       const isLocal = editing.nodeId === 'local'
-      const response = await apiService.updateNode(editing.nodeId, {
-        ...rest,
-        ...(!isLocal ? { sshPort: Number(sshPort) || 22 } : {}),
-        // 认证方式只随新凭据一起提交：服务端收到该字段就会覆盖，单独发送会把
-        // 私钥节点静默翻成无凭据的密码认证，之后所有 SSH 操作都会失败。
-        ...(sshCredential
-          ? sshAuthMethod === 'password'
-            ? { sshAuthMethod, sshPassword: sshCredential }
-            : { sshAuthMethod, sshPrivateKey: sshCredential }
-          : {}),
+      const response = await updateNode.mutateAsync({
+        nodeId: editing.nodeId,
+        patch: {
+          ...rest,
+          ...(!isLocal ? { sshPort: Number(sshPort) || 22 } : {}),
+          // 认证方式只随新凭据一起提交：服务端收到该字段就会覆盖，单独发送会把
+          // 私钥节点静默翻成无凭据的密码认证，之后所有 SSH 操作都会失败。
+          ...(sshCredential
+            ? sshAuthMethod === 'password'
+              ? { sshAuthMethod, sshPassword: sshCredential }
+              : { sshAuthMethod, sshPrivateKey: sshCredential }
+            : {}),
+        },
       })
       if (!response.success) throw new Error(response.error || '节点更新失败')
-      setEditing(null); await refresh(); toast.success('节点档案已更新')
+      setEditing(null); toast.success('节点档案已更新')
     } catch (caught) { setError(caught instanceof Error ? caught.message : '节点更新失败') }
     finally { setBusy(null) }
   }
@@ -91,9 +95,9 @@ export default function NodesPage() {
     setBusy(node.nodeId); setError(null)
     try {
       // HTTP 200 也可能携带 success:false；忽略它会让界面谎报“已暂停/已启用”。
-      const response = await apiService.updateNode(node.nodeId, { enabled: node.enabled === false })
+      const response = await updateNode.mutateAsync({ nodeId: node.nodeId, patch: { enabled: node.enabled === false } })
       if (!response.success) throw new Error(response.error || '节点状态更新失败')
-      await refresh(); toast.success(node.enabled === false ? '节点已启用纳管' : '节点已暂停纳管')
+      toast.success(node.enabled === false ? '节点已启用纳管' : '节点已暂停纳管')
     } catch (caught) { setError(caught instanceof Error ? caught.message : '节点状态更新失败') }
     finally { setBusy(null) }
   }
@@ -102,9 +106,9 @@ export default function NodesPage() {
     if (!window.confirm(`确认删除节点“${node.name}”？此操作会删除控制面档案和 SSH 凭据。`)) return
     setBusy(node.nodeId)
     try {
-      const result = await apiService.deleteNode(node.nodeId)
+      const result = await deleteNode.mutateAsync({ nodeId: node.nodeId })
       if (!result.success) throw new Error(result.error || '删除失败')
-      await refresh(); toast.success('节点档案已删除')
+      toast.success('节点档案已删除')
     } catch (caught) { setError(caught instanceof Error ? caught.message : '节点删除失败') }
     finally { setBusy(null) }
   }
@@ -112,10 +116,12 @@ export default function NodesPage() {
   return <SignalPage crumb="Node inventory" title="节点" description="管理节点档案、SSH 连接和纳管状态；软件安装与运行维护由后续页面负责。" status={`${cluster?.totalNodes || 0} 个节点档案`} maxWidth="narrow" actions={<><Button variant="outline" onClick={refresh}><Icon icon="ph:arrow-clockwise-light" />刷新</Button><Button onClick={() => setAddOpen(true)}><Icon icon="ph:plus-light" />添加节点</Button></>}>
     {error ? <Alert variant="destructive"><AlertTitle>节点操作失败</AlertTitle><AlertDescription>{error}</AlertDescription></Alert> : null}
     <Card className="mb-5"><CardContent className="grid gap-3 p-4 md:grid-cols-[1fr_220px]"><Input aria-label="搜索节点" value={query} onChange={event => setQuery(event.target.value)} placeholder="搜索名称、主机、地域或节点 ID…" /><Select aria-label="筛选节点" value={filter} onChange={event => setFilter(event.target.value as Filter)}><option value="all">全部节点</option><option value="enabled">已启用</option><option value="disabled">已暂停</option><option value="undeployed">Agent 未安装</option></Select></CardContent></Card>
-    <div className="grid gap-5 lg:grid-cols-2">
+    <QueryBoundary query={clusterQuery} skeleton={<div className="grid gap-5 lg:grid-cols-2">{Array.from({ length: 2 }).map((_, i) => <Skeleton key={i} className="h-52 w-full rounded-xl" />)}</div>}>
+      {() => <div className="grid gap-5 lg:grid-cols-2">
       {nodes.map(node => <Card key={node.nodeId}><CardHeader><div className="flex items-start justify-between gap-3"><div><CardTitle>{node.name}</CardTitle><CardDescription>{node.host || '主机未返回'} · {node.location} · {node.nodeId}</CardDescription></div><div className="flex gap-2"><Badge variant={node.enabled === false ? 'outline' : 'secondary'}>{node.enabled === false ? '已暂停' : '纳管中'}</Badge><Badge variant={node.online ? 'secondary' : 'outline'}>{node.online ? 'Agent 在线' : node.agent?.deployed ? 'Agent 异常' : 'Agent 未安装'}</Badge></div></div></CardHeader><CardContent className="space-y-4"><div className="grid grid-cols-2 gap-3 text-sm"><div className="rounded-2xl bg-[var(--surface-container)] p-3"><span className="block text-xs text-muted-foreground">{node.nodeId === 'local' ? '执行方式' : 'SSH'}</span><span className="mt-1 block font-mono">{node.nodeId === 'local' ? '本机直接执行' : `${node.sshUser || 'root'}@${node.host || '-'}:${node.sshPort || 22}`}</span></div><div className="rounded-2xl bg-[var(--surface-container)] p-3"><span className="block text-xs text-muted-foreground">已配置核心</span><span className="mt-1 block">{node.configuredKernels.map(item => item.type).join(' · ') || '无'}</span></div></div><div className="flex flex-wrap gap-2"><Button size="sm" variant="outline" onClick={() => openEdit(node)}>编辑档案</Button><Button size="sm" variant="outline" disabled={busy === node.nodeId} onClick={() => toggleEnabled(node)}>{node.enabled === false ? '启用纳管' : '暂停纳管'}</Button><Button asChild size="sm"><Link to={`/deploy?node=${encodeURIComponent(node.nodeId)}&component=agent`}>{node.agent?.deployed ? '查看部署' : '部署 Agent'}</Link></Button>{node.nodeId !== 'local' && (!node.agent?.deployed ? <Button size="sm" variant="destructive" disabled={busy === node.nodeId} onClick={() => remove(node)}>删除</Button> : <Button asChild size="sm" variant="outline"><Link to={`/deploy?node=${encodeURIComponent(node.nodeId)}&component=agent&operation=uninstall`}>先卸载再删除</Link></Button>)}</div></CardContent></Card>)}
       {nodes.length === 0 ? <Card><CardContent className="p-10 text-center"><p className="text-muted-foreground">没有匹配的节点。</p><Button className="mt-4" onClick={() => setAddOpen(true)}>添加第一个节点</Button></CardContent></Card> : null}
-    </div>
+    </div>}
+    </QueryBoundary>
 
     <Dialog open={Boolean(editing)} onOpenChange={open => { if (!open) setEditing(null) }}><DialogContent><DialogHeader><DialogTitle>编辑节点档案</DialogTitle><DialogDescription>{editing?.nodeId === 'local' ? '本机节点固定通过回环地址直接执行。' : '修改主机会清除已确认的 host key，下次部署前需要重新预检。'}</DialogDescription></DialogHeader><div className="grid gap-4 py-4"><div className="grid gap-2"><Label htmlFor="edit-name">名称</Label><Input id="edit-name" value={draft.name} onChange={event => setDraft(previous => ({ ...previous, name: event.target.value }))} /></div><div className="grid gap-2"><Label htmlFor="edit-host">主机</Label><Input id="edit-host" value={draft.host} disabled={editing?.nodeId === 'local'} onChange={event => setDraft(previous => ({ ...previous, host: event.target.value }))} /></div><div className="grid gap-2"><Label htmlFor="edit-location">地域标签</Label><Input id="edit-location" value={draft.location} onChange={event => setDraft(previous => ({ ...previous, location: event.target.value }))} /></div>
       <div className="grid gap-2 sm:grid-cols-2">

--- a/packages/frontend/src/pages/outputs.tsx
+++ b/packages/frontend/src/pages/outputs.tsx
@@ -1,10 +1,13 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useState } from 'react'
 import { Icon } from '@iconify/react'
 import { Link } from 'react-router-dom'
 import { toast } from 'sonner'
 import { apiService } from '@/lib/api'
+import { useArtifacts, useValidateArtifacts } from '@/lib/queries'
 import type { ArtifactState } from '@/lib/types'
 import { useAppContext } from '@/context/AppContext'
+import { QueryBoundary } from '@/components/shared/QueryBoundary'
+import { Skeleton } from '@/components/ui/skeleton'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -23,14 +26,11 @@ function freshnessLabel(value: ArtifactState['freshness']) {
 
 export default function OutputsPage() {
   const { openConvertModal } = useAppContext()
-  const [artifacts, setArtifacts] = useState<ArtifactState[]>([])
+  const artifactsQuery = useArtifacts()
+  const artifacts = artifactsQuery.data ?? []
+  const validateArtifacts = useValidateArtifacts()
   const [preview, setPreview] = useState<{ name: string; content: string; truncated: boolean } | null>(null)
   const [checking, setChecking] = useState(false)
-  const refresh = useCallback(async () => {
-    const response = await apiService.getArtifacts()
-    if (response.success && response.data) setArtifacts(response.data.artifacts)
-  }, [])
-  useEffect(() => { refresh().catch(() => {}) }, [refresh])
 
   const copyUrl = async (name: string) => {
     const url = new URL(`/${name}`, window.location.origin).toString()
@@ -47,8 +47,8 @@ export default function OutputsPage() {
   const validate = async () => {
     setChecking(true)
     try {
-      const response = await apiService.validateArtifacts()
-      if (response.success && response.data) setArtifacts(response.data.artifacts)
+      // mutation 成功后失效 artifacts 查询，列表自动刷新；这里只用返回值算未通过数量。
+      const response = await validateArtifacts.mutateAsync(undefined)
       const invalid = response.data?.artifacts.filter(item => !item.valid).length || 0
       if (invalid > 0) toast.warning(`${invalid} 个产物未通过验证`)
       else toast.success('三个正式产物均通过验证')
@@ -57,13 +57,19 @@ export default function OutputsPage() {
 
   return (
     <SignalPage crumb="Derived artifacts" title="衍生输出" description="负责正式产物的状态、预览、验证、URL、打开和下载；临时转换不会覆盖正式文件。" status={`${artifacts.filter(item => item.valid).length}/3 个产物有效`} maxWidth="narrow" actions={<><Button variant="outline" onClick={validate} disabled={checking}><Icon icon={checking ? 'ph:spinner-bold' : 'ph:shield-check-light'} className={checking ? 'animate-spin' : ''} />验证全部</Button><Button variant="outline" onClick={openConvertModal}><Icon icon="ph:arrows-left-right-light" />临时转换</Button></>}>
-      <div className="grid gap-5 xl:grid-cols-3">
+      <QueryBoundary
+        query={artifactsQuery}
+        skeleton={<div className="grid gap-5 xl:grid-cols-3">{Array.from({ length: 3 }).map((_, i) => <Skeleton key={i} className="h-64 w-full rounded-xl" />)}</div>}
+        isEmpty={(data: ArtifactState[]) => data.length === 0}
+        empty={<Card><CardContent className="p-8 text-center text-muted-foreground">产物状态尚未加载。</CardContent></Card>}
+      >
+      {() => <div className="grid gap-5 xl:grid-cols-3">
         {artifacts.map(item => {
           const meta = META[item.name]
           return <Card key={item.name}><CardHeader><div className="flex items-start justify-between gap-3"><div><CardDescription>{meta.description}</CardDescription><CardTitle className="mt-2">{meta.label}</CardTitle></div><Badge variant={item.valid ? 'secondary' : 'destructive'}>{item.valid ? freshnessLabel(item.freshness) : '无效/缺失'}</Badge></div></CardHeader><CardContent className="space-y-4"><div className="rounded-2xl bg-[var(--surface-container)] p-4"><code>{item.name}</code><p className="mt-2 text-xs text-muted-foreground">{meta.contentType} · {item.size} bytes</p><p className="mt-1 text-xs text-muted-foreground">{item.updatedAt ? new Date(item.updatedAt).toLocaleString('zh-CN') : '尚未生成'}{item.ageSeconds !== undefined ? ` · ${Math.floor(item.ageSeconds / 60)} 分钟前` : ''}</p>{item.validationError ? <p className="mt-2 text-xs text-destructive">{item.validationError}</p> : null}</div>{item.exists ? <div className="flex flex-wrap gap-2"><Button size="sm" variant="outline" onClick={() => copyUrl(item.name)}>复制 URL</Button><Button size="sm" variant="outline" onClick={() => openPreview(item.name)}>站内预览</Button><Button asChild size="sm" variant="outline"><a href={`/${item.name}`} target="_blank" rel="noreferrer">打开</a></Button><Button asChild size="sm"><a href={apiService.getDownloadUrl(item.name)} download>下载</a></Button></div> : <Button asChild size="sm"><Link to="/subscription">前往订阅生成</Link></Button>}</CardContent></Card>
         })}
-        {artifacts.length === 0 ? <Card className="xl:col-span-3"><CardContent className="p-8 text-center text-muted-foreground">产物状态尚未加载。</CardContent></Card> : null}
-      </div>
+      </div>}
+      </QueryBoundary>
       <Card className="mt-5"><CardHeader><CardTitle>临时手动转换</CardTitle><CardDescription>粘贴外部内容并临时生成 Clash YAML，不修改 raw.txt、subscription.txt、clash.yaml 或任务历史。</CardDescription></CardHeader><CardContent><Button onClick={openConvertModal}>打开临时转换器</Button></CardContent></Card>
       <Dialog open={Boolean(preview)} onOpenChange={open => { if (!open) setPreview(null) }}><DialogContent className="max-w-4xl"><DialogHeader><DialogTitle>{preview?.name} 预览</DialogTitle><DialogDescription>{preview?.truncated ? '内容较长，当前只显示前 64 KiB。' : '当前正式发布内容。'}</DialogDescription></DialogHeader><pre className="max-h-[65vh] overflow-auto rounded-2xl bg-[var(--surface-container-high)] p-4 text-xs leading-6">{preview?.content}</pre></DialogContent></Dialog>
     </SignalPage>

--- a/packages/frontend/src/pages/runtimes.tsx
+++ b/packages/frontend/src/pages/runtimes.tsx
@@ -3,8 +3,11 @@ import { Icon } from '@iconify/react'
 import { Link, useSearchParams } from 'react-router-dom'
 import { toast } from 'sonner'
 import { apiService } from '@/lib/api'
-import { KERNEL_TYPES, type ClusterStatus, type ComponentState, type KernelDetection, type KernelType, type NodeKernelConfig } from '@/lib/types'
+import { KERNEL_TYPES, type KernelDetection, type KernelType, type NodeKernelConfig } from '@/lib/types'
+import { useClusterStatus, useComponentStates, useKernelAction, useUpdateNodeKernels } from '@/lib/queries'
 import { KernelDetectionDialog } from '@/components/cluster/KernelDetectionDialog'
+import { QueryBoundary } from '@/components/shared/QueryBoundary'
+import { Skeleton } from '@/components/ui/skeleton'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -16,8 +19,8 @@ const LABELS: Record<KernelType, string> = { 'sing-box': 'sing-box', xray: 'Xray
 
 export default function RuntimesPage() {
   const [params, setParams] = useSearchParams()
-  const [cluster, setCluster] = useState<ClusterStatus | null>(null)
-  const [componentStates, setComponentStates] = useState<ComponentState[]>([])
+  const clusterQuery = useClusterStatus()
+  const cluster = clusterQuery.data ?? null
   const [detections, setDetections] = useState<KernelDetection[]>([])
   const [editorOpen, setEditorOpen] = useState(false)
   const [busy, setBusy] = useState<string | null>(null)
@@ -26,17 +29,13 @@ export default function RuntimesPage() {
   const nodeId = params.get('node') || nodes[0]?.nodeId || ''
   const node = nodes.find(item => item.nodeId === nodeId)
 
-  const refreshCluster = useCallback(async () => {
-    const result = await apiService.getClusterStatus()
-    if (result.success) setCluster(result.data as ClusterStatus)
-  }, [])
-
   // 运行态与二进制路径是组件状态接口的权威字段，不能由前端按内核类型猜测。
-  const refreshComponents = useCallback(async (targetId = nodeId) => {
-    if (!targetId) return
-    const result = await apiService.getComponentStates([targetId])
-    if (result.success && result.data) setComponentStates(result.data.states)
-  }, [nodeId])
+  // 按 nodeId 分 key 缓存：切换节点自动拉取新节点状态，无需手动清空。
+  const componentStatesQuery = useComponentStates(nodeId ? [nodeId] : undefined, { enabled: Boolean(nodeId) })
+  const componentStates = componentStatesQuery.data ?? []
+
+  const updateNodeKernels = useUpdateNodeKernels()
+  const kernelAction = useKernelAction()
 
   const detect = useCallback(async (targetId = nodeId) => {
     if (!targetId) return
@@ -49,8 +48,6 @@ export default function RuntimesPage() {
     } finally { setBusy(null) }
   }, [nodeId])
 
-  useEffect(() => { refreshCluster().catch(() => {}) }, [refreshCluster])
-  useEffect(() => { refreshComponents().catch(() => {}) }, [refreshComponents])
   useEffect(() => { if (nodeId && node?.agent?.deployed) detect(nodeId).catch(() => {}) }, [detect, node?.agent?.deployed, nodeId])
 
   const selectNode = (value: string) => {
@@ -58,7 +55,6 @@ export default function RuntimesPage() {
     next.set('node', value)
     setParams(next)
     setDetections([])
-    setComponentStates([])
   }
 
   const saveMonitoring = useCallback(async (kernels: NodeKernelConfig[]) => {
@@ -67,32 +63,31 @@ export default function RuntimesPage() {
     // 与 detect/maintain 保持一致：不清空旧错误会让上一次失败的提示滞留在本次操作上。
     setError(null)
     try {
-      const result = await apiService.updateNodeKernels(node.nodeId, kernels)
+      const result = await updateNodeKernels.mutateAsync({ nodeId: node.nodeId, kernels })
       if (!result.success) throw new Error(result.error || '监控配置保存失败')
       setEditorOpen(false)
       toast.success('监控配置已写入远端并通过 Agent 验证')
-      await refreshCluster()
-      await refreshComponents(node.nodeId)
+      // mutation 已失效 cluster-status 与 component-states，自动刷新；仅需重新检测。
       await detect(node.nodeId)
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : '监控配置保存失败')
     } finally { setBusy(null) }
-  }, [detect, node, refreshCluster, refreshComponents])
+  }, [detect, node, updateNodeKernels])
 
   const maintain = useCallback(async (type: KernelType, action: 'start' | 'stop' | 'restart') => {
     if (!node) return
     setBusy(`${node.nodeId}:${type}:${action}`)
     setError(null)
     try {
-      const result = await apiService.kernelAction(node.nodeId, type, action)
+      const result = await kernelAction.mutateAsync({ nodeId: node.nodeId, kernelType: type, action })
       if (!result.success) throw new Error(result.error || `${action} 失败`)
       toast.success(`${LABELS[type]} ${action} 完成`)
-      await refreshComponents(node.nodeId)
+      // mutation 已失效 component-states，自动刷新；仅需重新检测。
       await detect(node.nodeId)
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : '运行时维护失败')
     } finally { setBusy(null) }
-  }, [detect, node, refreshComponents])
+  }, [detect, node, kernelAction])
 
   return (
     <SignalPage crumb="Runtime operations" title="运行时" description="维护 mihomo 与协议核心的运行状态、配置路径和 Agent 监控范围。" status={node ? `${node.name} · ${detections.filter(item => item.installed).length} 个协议核心已安装` : '请选择节点'} maxWidth="narrow" actions={<Button variant="outline" onClick={() => detect()} disabled={!nodeId || busy !== null}><Icon icon={busy?.endsWith(':detect') ? 'ph:spinner-bold' : 'ph:magnifying-glass-light'} className={busy?.endsWith(':detect') ? 'animate-spin' : ''} />检测运行时</Button>}>
@@ -103,7 +98,8 @@ export default function RuntimesPage() {
         <CardHeader className="md:flex-row md:items-end md:justify-between"><div><CardTitle>目标节点</CardTitle><CardDescription>运行维护只作用于一个明确节点。</CardDescription></div><div className="min-w-[260px]"><Select aria-label="目标节点" value={nodeId} onChange={event => selectNode(event.target.value)}><option value="">选择节点</option>{nodes.map(item => <option key={item.nodeId} value={item.nodeId}>{item.name} · {item.location}</option>)}</Select></div></CardHeader>
       </Card>
 
-      {node ? <div className="grid gap-5 lg:grid-cols-2">
+      <QueryBoundary query={clusterQuery} skeleton={<div className="grid gap-5 lg:grid-cols-2">{Array.from({ length: 2 }).map((_, i) => <Skeleton key={i} className="h-56 w-full rounded-xl" />)}</div>}>
+      {() => node ? <div className="grid gap-5 lg:grid-cols-2">
         <Card>
           <CardHeader><div className="flex items-start justify-between gap-3"><div><CardTitle>mihomo</CardTitle><CardDescription>Clash 转换与产物验证运行时</CardDescription></div><Badge variant={node.mihomoAvailable ? 'secondary' : 'outline'}>{node.mihomoAvailable ? '可用' : '未安装/未知'}</Badge></div></CardHeader>
           <CardContent className="space-y-4">
@@ -137,6 +133,7 @@ export default function RuntimesPage() {
           )
         })}
       </div> : <Card><CardContent className="p-10 text-center text-muted-foreground">请先选择节点；如果没有节点，请先在节点页添加。</CardContent></Card>}
+      </QueryBoundary>
 
       {editorOpen && node ? <KernelDetectionDialog open detections={detections} monitored={node.configuredKernels} submitting={busy === `${node.nodeId}:monitoring`} error={error} confirmLabel="保存并验证监控配置" onCancel={() => setEditorOpen(false)} onConfirm={saveMonitoring} /> : null}
     </SignalPage>

--- a/packages/frontend/src/pages/subscription-status.tsx
+++ b/packages/frontend/src/pages/subscription-status.tsx
@@ -1,9 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { Icon } from '@iconify/react'
 import { Link } from 'react-router-dom'
 import { toast } from 'sonner'
-import { apiService, type ApiStatus } from '@/lib/api'
-import type { ArtifactState, SubscriptionJob, SubscriptionPolicy } from '@/lib/types'
+import {
+  queryKeys, useArtifacts, useStatus, useSubscriptionJobs, useSubscriptionPolicy, useUpdateSubscriptionPolicy,
+} from '@/lib/queries'
+import type { SubscriptionJob, SubscriptionPolicy } from '@/lib/types'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -43,9 +46,15 @@ function nodeDropCheck(jobs: SubscriptionJob[], threshold: number): { ok: boolea
 }
 
 export default function SubscriptionStatusPage() {
-  const [status, setStatus] = useState<ApiStatus | null>(null)
-  const [artifacts, setArtifacts] = useState<ArtifactState[]>([])
-  const [jobs, setJobs] = useState<SubscriptionJob[]>([])
+  const queryClient = useQueryClient()
+  const statusQuery = useStatus()
+  const artifactsQuery = useArtifacts()
+  const jobsQuery = useSubscriptionJobs()
+  const policyQuery = useSubscriptionPolicy()
+  const updatePolicy = useUpdateSubscriptionPolicy()
+  const status = statusQuery.data ?? null
+  const artifacts = useMemo(() => artifactsQuery.data ?? [], [artifactsQuery.data])
+  const jobs = useMemo(() => jobsQuery.data ?? [], [jobsQuery.data])
   const [policy, setPolicy] = useState<SubscriptionPolicy>(DEFAULT_POLICY)
   const [draft, setDraft] = useState<SubscriptionPolicy>(DEFAULT_POLICY)
   // 重试间隔是自由文本，必须独立保存，否则用户敲到 "2," 时会被立刻改写。
@@ -75,34 +84,39 @@ export default function SubscriptionStatusPage() {
     })
   }, [])
 
-  const refresh = useCallback(async () => {
+  // 真实拉取每个公共 URL：产物元数据说“存在”不等于对外真的能取到。apiService 不覆盖
+  // 这些同源静态路径，保留独立 fetch 探测。
+  const probePublicUrls = useCallback(async () => {
+    const probes = await Promise.all(PUBLIC_URLS.map(async path => {
+      try {
+        const response = await fetch(path, { cache: 'no-store' })
+        return { path, ok: response.ok }
+      } catch { return { path, ok: false } }
+    }))
+    setPublicUrls(probes)
+  }, [])
+  useEffect(() => { void probePublicUrls() }, [probePublicUrls])
+
+  // 生效策略随查询更新；只有草稿仍等于旧生效值（用户没有未保存的编辑）时才跟随刷新，
+  // 否则迟到的响应会静默吞掉用户已经输入的内容。要放弃编辑请用「放弃草稿」。
+  useEffect(() => {
+    if (!policyQuery.data) return
+    const next = policyQuery.data
+    const baseline = policyRef.current
+    applyPolicy(next)
+    if (JSON.stringify(draftRef.current) === JSON.stringify(baseline)) resetDraft(next)
+  }, [policyQuery.data, applyPolicy, resetDraft])
+
+  const refresh = useCallback(() => {
     setError(null)
-    try {
-      const [nextStatus, artifactResponse, jobResponse, policyResponse, probes] = await Promise.all([
-        apiService.getStatus(), apiService.getArtifacts(), apiService.getSubscriptionJobs(), apiService.getSubscriptionPolicy(),
-        // 真实拉取每个公共 URL：产物元数据说“存在”不等于对外真的能取到。
-        Promise.all(PUBLIC_URLS.map(async path => {
-          try {
-            const response = await fetch(path, { cache: 'no-store' })
-            return { path, ok: response.ok }
-          } catch { return { path, ok: false } }
-        })),
-      ])
-      setStatus(nextStatus)
-      setPublicUrls(probes)
-      if (artifactResponse.success && artifactResponse.data) setArtifacts(artifactResponse.data.artifacts)
-      if (jobResponse.success && jobResponse.data) setJobs(jobResponse.data.jobs)
-      if (policyResponse.success && policyResponse.data) {
-        const next = policyResponse.data
-        const baseline = policyRef.current
-        applyPolicy(next)
-        // 只有草稿仍与旧生效值一致（用户没有未保存的编辑）时才跟随刷新；
-        // 否则迟到的响应会静默吞掉用户已经输入的内容。要放弃编辑请用「放弃草稿」。
-        if (JSON.stringify(draftRef.current) === JSON.stringify(baseline)) resetDraft(next)
-      }
-    } catch (caught) { setError(caught instanceof Error ? caught.message : '状态检查失败') }
-  }, [applyPolicy, resetDraft])
-  useEffect(() => { refresh().catch(() => {}) }, [refresh])
+    void queryClient.invalidateQueries({ queryKey: queryKeys.status })
+    void queryClient.invalidateQueries({ queryKey: queryKeys.artifacts })
+    void queryClient.invalidateQueries({ queryKey: queryKeys.subscriptionJobs })
+    void queryClient.invalidateQueries({ queryKey: queryKeys.subscriptionPolicy })
+    void probePublicUrls()
+  }, [probePublicUrls, queryClient])
+
+  const loadError = (statusQuery.error ?? artifactsQuery.error ?? jobsQuery.error ?? policyQuery.error)?.message ?? null
 
   const latestJob = jobs[0]
   const checks = useMemo(() => [
@@ -124,7 +138,7 @@ export default function SubscriptionStatusPage() {
   const savePolicy = async () => {
     setSaving(true); setError(null)
     try {
-      const response = await apiService.updateSubscriptionPolicy(draft)
+      const response = await updatePolicy.mutateAsync(draft)
       if (!response.success || !response.data) throw new Error('定时策略保存失败')
       applyPolicy(response.data); resetDraft(response.data); toast.success('订阅策略已保存')
     } catch (caught) { setError(caught instanceof Error ? caught.message : '定时策略保存失败') }
@@ -133,7 +147,7 @@ export default function SubscriptionStatusPage() {
 
   return (
     <SignalPage crumb="Subscription health" title="订阅状态" description="维护正式产物的新鲜度、格式、公共 URL、上次任务与定时生成策略。" status={healthy ? '订阅健康' : `${checks.filter(item => !item.ok).length} 个问题待处理`} maxWidth="narrow" actions={<Button variant="outline" onClick={refresh}><Icon icon="ph:heartbeat-light" />立即检查</Button>}>
-      {error ? <Alert variant="destructive"><AlertTitle>状态检查失败</AlertTitle><AlertDescription>{error}</AlertDescription></Alert> : null}
+      {(error ?? loadError) ? <Alert variant="destructive"><AlertTitle>状态检查失败</AlertTitle><AlertDescription>{error ?? loadError}</AlertDescription></Alert> : null}
       {!healthy ? <Alert variant="destructive"><AlertTitle>订阅闭环未完成</AlertTitle><AlertDescription>本页只诊断和维护策略；需要生成、运行时维护或产物操作时跳转到唯一负责页面。</AlertDescription></Alert> : <Alert variant="success"><AlertTitle>所有检查通过</AlertTitle><AlertDescription>正式订阅及兼容 URL 当前可用。</AlertDescription></Alert>}
       <div className="mt-5 grid gap-4 md:grid-cols-2">{checks.map(item => <Card key={item.label}><CardContent className="flex items-center justify-between gap-4 p-5"><div><p className="font-medium">{item.label}</p><p className="mt-1 text-sm text-muted-foreground">{item.detail}</p></div><Badge variant={item.ok ? 'secondary' : 'destructive'}>{item.ok ? '通过' : '异常'}</Badge></CardContent></Card>)}</div>
 

--- a/packages/frontend/src/pages/subscription.tsx
+++ b/packages/frontend/src/pages/subscription.tsx
@@ -1,10 +1,15 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { Icon } from '@iconify/react'
 import { Link } from 'react-router-dom'
 import { toast } from 'sonner'
 import { apiService } from '@/lib/api'
 import { streamServerEvents } from '@/lib/sse'
-import type { ClusterStatus, SubscriptionJob, SubscriptionPreflight } from '@/lib/types'
+import {
+  queryKeys, useClusterStatus, useRetrySubscriptionJob, useStartSubscriptionJob,
+  useSubscriptionJobs, useSubscriptionPreflight,
+} from '@/lib/queries'
+import type { SubscriptionJob } from '@/lib/types'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -31,29 +36,31 @@ function jobBadge(job: SubscriptionJob) {
 }
 
 export default function SubscriptionPage() {
-  const [cluster, setCluster] = useState<ClusterStatus | null>(null)
-  const [preflight, setPreflight] = useState<SubscriptionPreflight | null>(null)
-  const [jobs, setJobs] = useState<SubscriptionJob[]>([])
+  const queryClient = useQueryClient()
+  // SSE 实时更新，轮询 5s 兜底；tab 隐藏时暂停。
+  const pollOptions = { refetchInterval: 5000, refetchIntervalInBackground: false } as const
+  const clusterQuery = useClusterStatus(pollOptions)
+  const preflightQuery = useSubscriptionPreflight(pollOptions)
+  const jobsQuery = useSubscriptionJobs(pollOptions)
+  const cluster = clusterQuery.data ?? null
+  const preflight = preflightQuery.data ?? null
+  const jobs = useMemo(() => jobsQuery.data ?? [], [jobsQuery.data])
+  const startJob = useStartSubscriptionJob()
+  const retryJob = useRetrySubscriptionJob()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   // 进度流断开必须显式暴露：静默关闭连接会让页面停在过期进度上，用户以为任务卡住了。
   const [streamBroken, setStreamBroken] = useState(false)
   const [streamAttempt, setStreamAttempt] = useState(0)
 
+  // queryClient 身份稳定，refresh 因此稳定，SSE 副作用不会因刷新回调变化而反复重连。
   const refresh = useCallback(async () => {
-    const [clusterResponse, preflightResponse, jobResponse] = await Promise.all([
-      apiService.getClusterStatus(), apiService.preflightSubscription(), apiService.getSubscriptionJobs(),
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: queryKeys.clusterStatus }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.subscriptionPreflight }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.subscriptionJobs }),
     ])
-    if (clusterResponse.success) setCluster(clusterResponse.data as ClusterStatus)
-    if (preflightResponse.success && preflightResponse.data) setPreflight(preflightResponse.data)
-    if (jobResponse.success && jobResponse.data) setJobs(jobResponse.data.jobs)
-  }, [])
-
-  useEffect(() => {
-    refresh().catch(caught => setError(caught instanceof Error ? caught.message : '订阅任务加载失败'))
-    const timer = window.setInterval(() => refresh().catch(() => {}), 5000)
-    return () => window.clearInterval(timer)
-  }, [refresh])
+  }, [queryClient])
 
   const activeJobs = useMemo(() => jobs.filter(job => job.status === 'queued' || job.status === 'running'), [jobs])
   useEffect(() => {
@@ -79,29 +86,27 @@ export default function SubscriptionPage() {
     try {
       const check = await apiService.preflightSubscription()
       if (!check.success || !check.data?.ready) throw new Error(check.data?.blockingErrors.join('；') || message(check.error, '没有可读来源'))
-      const response = await apiService.startSubscriptionJob()
+      const response = await startJob.mutateAsync()
       if (!response.success) throw new Error(message(response.error, '创建订阅任务失败'))
       toast.success('订阅任务已持久化并进入队列', { description: response.data?.jobId })
-      await refresh()
     } catch (caught) {
       const detail = caught instanceof Error ? caught.message : '创建订阅任务失败'
       setError(detail); toast.error('订阅生成未启动', { description: detail })
     } finally { setLoading(false) }
-  }, [refresh])
+  }, [startJob])
 
   const retry = useCallback(async (job: SubscriptionJob) => {
     // apiService 在 HTTP 失败时抛出 ApiError，不捕获的话异常会逃逸且用户看不到任何反馈。
     try {
-      const response = await apiService.retrySubscriptionJob(job.id)
+      const response = await retryJob.mutateAsync(job.id)
       if (!response.success) throw new Error(message(response.error, '无法按原输入重试'))
       toast.success('已按上次输入创建重试任务')
-      await refresh()
     } catch (caught) {
       const detail = caught instanceof Error ? caught.message : '无法按原输入重试'
       setError(detail)
       toast.error('任务重试失败', { description: detail })
     }
-  }, [refresh])
+  }, [retryJob])
 
   return (
     <SignalPage crumb="Subscription jobs" title="订阅生成" description="先预检来源，再以持久化任务执行采集、解析、去重、转换、验证、发布和备份。" status={`${preflight?.sourcesTotal || 0} 个来源 · ${activeJobs.length} 个活动任务`} maxWidth="narrow" actions={<Button variant="outline" onClick={refresh}><Icon icon="ph:arrow-clockwise-light" />重新预检</Button>}>

--- a/packages/frontend/src/test/renderWithClient.tsx
+++ b/packages/frontend/src/test/renderWithClient.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+export function makeTestClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+}
+
+export function renderWithClient(ui: React.ReactElement, client = makeTestClient()) {
+  return { client, ...render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>) }
+}


### PR DESCRIPTION
## What changed

- add a shared TanStack Query client, query keys, read hooks, and mutation hooks
- migrate dashboard pages and navigation status reads to shared cached queries
- add consistent loading/error boundaries and skeleton states
- pause hidden polling and share cluster status data across consumers
- add focused query/mutation tests and update existing component tests
- accept readonly TanStack Query keys in the cache invalidation helper

## Why

The dashboard previously duplicated request state and polling across pages, which made refresh behavior, cache consistency, and loading/error handling difficult to coordinate. This centralizes the data layer and invalidation rules.

## Impact

Dashboard reads are cached and shared, mutations invalidate the relevant data, polling is more efficient, and loading/error states are consistent.

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run --cwd packages/frontend test` (14 files, 61 tests)
- `bun run build`
