### PR TITLE
fix(core): cache cluster-status fan-out to stop request stalls

### DIFF
--- a/packages/cli/src/dashboard/server/applicationRoutes.ts
+++ b/packages/cli/src/dashboard/server/applicationRoutes.ts
@@ -86,7 +86,8 @@ export function registerApplicationRoutes(registrar: DashboardRouteRegistrar, de
     const body = object(req.body);
     const nodeId = string(body.nodeId, 'nodeId');
     await deps.operations.detectKernels({ nodeId });
-    await sendResult(req, res, await deps.operations.getComponentStates([nodeId]));
+    // 刚触发过检测：绕过集群状态缓存，让返回的组件状态反映这次检测结果。
+    await sendResult(req, res, await deps.operations.getComponentStates([nodeId], true));
   });
 
   route(registrar, 'POST', '/api/cluster/components/:component/:action', async (req, res) => {

--- a/packages/cli/src/dashboard/server/composition.ts
+++ b/packages/cli/src/dashboard/server/composition.ts
@@ -59,7 +59,7 @@ export interface DashboardOperationsPort {
   readonly getDeploymentEvents: (taskId: string, afterEventId?: string) => Promise<OperationsResult>;
   readonly getDeploymentLog: (taskId: string) => Promise<OperationsResult>;
   readonly getManualAgentConfig: (nodeId: string) => Promise<OperationsResult>;
-  readonly getComponentStates: (nodeIds?: string[]) => Promise<OperationsResult>;
+  readonly getComponentStates: (nodeIds?: string[], forceRefresh?: boolean) => Promise<OperationsResult>;
 }
 
 // ── Config + logs ───────────────────────────────────────────────────

--- a/packages/cli/src/dashboard/server/nodeDependencies.ts
+++ b/packages/cli/src/dashboard/server/nodeDependencies.ts
@@ -237,9 +237,9 @@ export function createNodeDashboardDependencies(composition: NodeCoreComposition
       async getManualAgentConfig(nodeId) {
         return result({ nodeId, content: await deployment.manualAgentConfig(nodeId) });
       },
-      async getComponentStates(nodeIds) {
+      async getComponentStates(nodeIds, forceRefresh) {
         const [cluster, taskRecord] = await Promise.all([
-          composition.aggregation.getClusterStatus(),
+          composition.aggregation.getClusterStatus({ forceRefresh: forceRefresh === true }),
           deployment.getComponentDeployments(nodeIds),
         ]);
         const allowed = nodeIds ? new Set(nodeIds) : null;

--- a/packages/core/src/nodes/nodeAggregationService.ts
+++ b/packages/core/src/nodes/nodeAggregationService.ts
@@ -13,12 +13,23 @@ export class NodeAggregationService {
   private readonly cache = new Map<string, NodeStatus>();
   /** 已经从持久化存储回填过 lastError 的节点，避免每次轮询都读一次。 */
   private readonly hydrated = new Set<string>();
+  /** 集群状态是一次对全部节点的实时扇出，多个端点（status/health/metrics/components…）
+   *  会同时轮询它。短 TTL 缓存 + in-flight 去重把这些并发轮询折叠成一次扇出，
+   *  避免任何一个慢/不可达节点把每个调用方都拖满 10s。 */
+  private readonly statusTtlMs: number;
+  private readonly now: () => number;
+  private statusCache: { at: number; value: ClusterStatus } | undefined;
+  private statusInFlight: Promise<ClusterStatus> | undefined;
   constructor(
     private readonly repository: NodeRepository,
     private readonly agent: AgentClient,
     /** 可选：提供后「最近错误」可以跨进程重启保留。 */
     private readonly state?: StateStore,
-  ) {}
+    options: { statusTtlMs?: number; now?: () => number } = {},
+  ) {
+    this.statusTtlMs = options.statusTtlMs ?? 2_000;
+    this.now = options.now ?? Date.now;
+  }
   getNodeCache(): ReadonlyMap<string, NodeStatus> { return this.cache; }
 
   private async loadLastError(nodeId: string): Promise<string | undefined> {
@@ -43,7 +54,25 @@ export class NodeAggregationService {
     return { sources: results.flatMap(r => r.sources), errors: results.flatMap(r => r.errors) };
   }
 
-  async getClusterStatus(): Promise<ClusterStatus> {
+  async getClusterStatus(options: { forceRefresh?: boolean } = {}): Promise<ClusterStatus> {
+    if (!options.forceRefresh) {
+      const cached = this.statusCache;
+      if (cached && this.now() - cached.at < this.statusTtlMs) return cached.value;
+      // 已有一次扇出在途：并发调用方复用它，而不是各自再打一轮全节点请求。
+      if (this.statusInFlight) return this.statusInFlight;
+    }
+    const run = this.computeClusterStatus();
+    this.statusInFlight = run;
+    try {
+      const value = await run;
+      this.statusCache = { at: this.now(), value };
+      return value;
+    } finally {
+      if (this.statusInFlight === run) this.statusInFlight = undefined;
+    }
+  }
+
+  private async computeClusterStatus(): Promise<ClusterStatus> {
     const nodes = await this.repository.list({ enabledOnly: false });
     const enabledNodes = nodes.filter(node => node.enabled);
     const [statuses, collection] = await Promise.all([Promise.all(nodes.map(node => this.status(node))), Promise.all(enabledNodes.map(node => this.collectSources(node)))]);

--- a/packages/core/test/nodes/services.test.ts
+++ b/packages/core/test/nodes/services.test.ts
@@ -166,4 +166,33 @@ describe('node core services', () => {
     expect(recovered.nodes[0]?.error).toBeUndefined();
     expect(recovered.nodes[0]?.lastError).toContain('offline');
   });
+
+  it('collapses concurrent and rapid cluster-status polls into a single fan-out', async () => {
+    const repository = new NodeRepository(memoryStore(`nodes:\n  - id: node-a\n    name: A\n    host: agent.example\n    secret: secret\n    kernels:\n      - type: xray\n    location: HK\n    enabled: true\n`));
+    let calls = 0;
+    const client = new AgentClient({ fetch: (async () => { calls++; return new Response(
+      JSON.stringify({ data: { kernels, sources: [{ kernel: 'xray', url: 'vless://id@example.com:443' }] } }),
+      { status: 200 },
+    ); }) as typeof fetch });
+    let clock = 1_000;
+    const service = new NodeAggregationService(repository, client, undefined, { statusTtlMs: 5_000, now: () => clock });
+
+    // 多个端点同时轮询：in-flight 去重把它们折叠成一次扇出。
+    // 单节点每轮 = status() + collectSources() = 2 次 fetch。
+    await Promise.all([service.getClusterStatus(), service.getClusterStatus(), service.getClusterStatus()]);
+    expect(calls).toBe(2);
+
+    // TTL 内再轮询：命中缓存，零扇出。
+    await service.getClusterStatus();
+    expect(calls).toBe(2);
+
+    // forceRefresh 绕过缓存，重新扇出。
+    await service.getClusterStatus({ forceRefresh: true });
+    expect(calls).toBe(4);
+
+    // TTL 过期后自动重新扇出。
+    clock += 6_000;
+    await service.getClusterStatus();
+    expect(calls).toBe(6);
+  });
 });


### PR DESCRIPTION
## 问题
`GET /api/cluster/status` 卡顿。根因非死锁，乃 `NodeAggregationService.getClusterStatus` 对**全部节点做实时 HTTP 扇出**并 `Promise.all` 阻塞至最慢节点落定（仅受 10s `AgentClient` 超时限制）。

同款扇出经由 8 个端点共用、无缓存：`cluster/status`、`cluster/health`、`cluster/components`、`components/detect`、`components/:c/monitoring`、`/api/metrics`、`/api/diagnostics`、metrics 抓取。`status`+`health`+`metrics`+`components` 并发轮询 → 数倍放大。

## 改动
- `getClusterStatus` 加 **2s TTL 缓存** + **in-flight 去重**：并发/快速轮询折叠成一次扇出。
- 新增 `forceRefresh` 选项，穿到 `getComponentStates`；`POST /api/cluster/components/detect` 检测后置读绕过缓存，保持正确性。
- 未动 reconcile 回写（仅状态变化时触发，稳态零开销）。

## 验证
- `core:typecheck` / `cli:typecheck` 通过
- core 52 测（新增并发/TTL/forceRefresh 用例）、cli 163 测 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)