### PR TITLE
fix(core): serve cluster status stale-while-revalidate; feat: adopt detected kernels

### DIFF
--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -8,7 +8,7 @@ import { formatLocalNodeConfiguration, type LocalNodeConfigurationService } from
 import { formatDashboardDaemonStatus, type DashboardDaemonAction } from './dashboard/commands.js';
 import type { DashboardDaemonStatus } from './dashboard/systemd.js';
 
-export const CLI_VERSION = process.env.MIOBRIDGE_BUILD_VERSION ?? '1.2.12';
+export const CLI_VERSION = process.env.MIOBRIDGE_BUILD_VERSION ?? '1.2.15';
 
 export interface CliCore {
   updateSubscription(): Promise<UpdateResult>;

--- a/packages/core/src/nodes/nodeAggregationService.ts
+++ b/packages/core/src/nodes/nodeAggregationService.ts
@@ -14,9 +14,13 @@ export class NodeAggregationService {
   /** 已经从持久化存储回填过 lastError 的节点，避免每次轮询都读一次。 */
   private readonly hydrated = new Set<string>();
   /** 集群状态是一次对全部节点的实时扇出，多个端点（status/health/metrics/components…）
-   *  会同时轮询它。短 TTL 缓存 + in-flight 去重把这些并发轮询折叠成一次扇出，
-   *  避免任何一个慢/不可达节点把每个调用方都拖满 10s。 */
+   *  会同时轮询它。缓存 + in-flight 去重 + stale-while-revalidate 让状态端点
+   *  永不阻塞在实时扇出上：有旧快照即刻返回、过期后台刷新，只有冷启动才真跑，
+   *  且冷启动的每节点探测超时很短，绝不把 HTTP 请求拖到前端超时。 */
   private readonly statusTtlMs: number;
+  /** 状态扇出的每节点探测超时。刻意远短于 AgentClient 默认的 10s（部署/日志用），
+   *  这样即便某节点不可达，冷启动也能快速兜底返回而非拖满整条请求。 */
+  private readonly statusProbeTimeoutMs: number;
   private readonly now: () => number;
   private statusCache: { at: number; value: ClusterStatus } | undefined;
   private statusInFlight: Promise<ClusterStatus> | undefined;
@@ -25,9 +29,10 @@ export class NodeAggregationService {
     private readonly agent: AgentClient,
     /** 可选：提供后「最近错误」可以跨进程重启保留。 */
     private readonly state?: StateStore,
-    options: { statusTtlMs?: number; now?: () => number } = {},
+    options: { statusTtlMs?: number; statusProbeTimeoutMs?: number; now?: () => number } = {},
   ) {
     this.statusTtlMs = options.statusTtlMs ?? 2_000;
+    this.statusProbeTimeoutMs = options.statusProbeTimeoutMs ?? 5_000;
     this.now = options.now ?? Date.now;
   }
   getNodeCache(): ReadonlyMap<string, NodeStatus> { return this.cache; }
@@ -55,34 +60,44 @@ export class NodeAggregationService {
   }
 
   async getClusterStatus(options: { forceRefresh?: boolean } = {}): Promise<ClusterStatus> {
-    if (!options.forceRefresh) {
-      const cached = this.statusCache;
-      if (cached && this.now() - cached.at < this.statusTtlMs) return cached.value;
-      // 已有一次扇出在途：并发调用方复用它，而不是各自再打一轮全节点请求。
-      if (this.statusInFlight) return this.statusInFlight;
+    const cached = this.statusCache;
+    if (!options.forceRefresh && cached) {
+      // stale-while-revalidate：立刻回上次快照，过期就丢一个后台刷新。
+      // 请求线程绝不等待实时扇出，故任何慢节点都无法把响应拖到前端超时。
+      if (this.now() - cached.at >= this.statusTtlMs) this.refreshInBackground();
+      return cached.value;
     }
-    const run = this.computeClusterStatus();
+    // 冷启动（尚无任何快照）或强制刷新：这次必须真跑，但每节点探测超时很短。
+    return this.runClusterStatus();
+  }
+
+  /** 过期后台刷新：不阻塞任何调用方，错误吞掉（下次探测会再试），避免 unhandled rejection。 */
+  private refreshInBackground(): void {
+    if (this.statusInFlight) return;
+    this.runClusterStatus().catch(() => undefined);
+  }
+
+  /** 真正跑一次扇出。并发调用复用同一个 in-flight，成功后写入缓存。 */
+  private runClusterStatus(): Promise<ClusterStatus> {
+    if (this.statusInFlight) return this.statusInFlight;
+    const run = this.computeClusterStatus()
+      .then(value => { this.statusCache = { at: this.now(), value }; return value; })
+      .finally(() => { if (this.statusInFlight === run) this.statusInFlight = undefined; });
     this.statusInFlight = run;
-    try {
-      const value = await run;
-      this.statusCache = { at: this.now(), value };
-      return value;
-    } finally {
-      if (this.statusInFlight === run) this.statusInFlight = undefined;
-    }
+    return run;
   }
 
   private async computeClusterStatus(): Promise<ClusterStatus> {
     const nodes = await this.repository.list({ enabledOnly: false });
     const enabledNodes = nodes.filter(node => node.enabled);
-    const [statuses, collection] = await Promise.all([Promise.all(nodes.map(node => this.status(node))), Promise.all(enabledNodes.map(node => this.collectSources(node)))]);
+    const [statuses, collection] = await Promise.all([Promise.all(nodes.map(node => this.status(node, this.statusProbeTimeoutMs))), Promise.all(enabledNodes.map(node => this.collectSources(node, this.statusProbeTimeoutMs)))]);
     const sources = collection.flatMap(result => result.sources);
     return { totalNodes: statuses.length, onlineNodes: statuses.filter(s => s.online).length, totalProxies: dedupeProxySources(sources).length, nodes: statuses, lastUpdated: new Date().toISOString() };
   }
 
-  private async collectSources(node: NodeConfig): Promise<RemoteSourceCollection> {
+  private async collectSources(node: NodeConfig, timeoutMs?: number): Promise<RemoteSourceCollection> {
     try {
-      const json = await this.agent.get(node, '/api/urls') as Record<string, unknown>;
+      const json = await this.agent.get(node, '/api/urls', timeoutMs) as Record<string, unknown>;
       const data = (json.data ?? json) as Record<string, unknown>;
       const kernels = this.agent.validateKernelStatuses(data.kernels);
       if (!Array.isArray(data.sources)) throw new Error('Agent 返回了无效的代理来源');
@@ -105,7 +120,7 @@ export class NodeAggregationService {
     } catch (error) { return { sources: [], errors: [this.error(node, error instanceof Error ? error.message : String(error))] }; }
   }
 
-  private async status(node: NodeConfig): Promise<NodeStatus> {
+  private async status(node: NodeConfig, timeoutMs?: number): Promise<NodeStatus> {
     const base: NodeStatus = {
       nodeId: node.id, name: node.name, host: node.host, configuredKernels: node.kernels,
       kernels: unavailable(node.kernels), location: node.location, enabled: node.enabled,
@@ -117,7 +132,7 @@ export class NodeAggregationService {
     // 但用户仍需要看到上一次失败的原因才能判断要不要进排障链路。
     const previousError = await this.loadLastError(node.id);
     try {
-      const json = await this.agent.get(node, '/api/status') as Record<string, unknown>;
+      const json = await this.agent.get(node, '/api/status', timeoutMs) as Record<string, unknown>;
       const data = (json.data ?? json) as Record<string, unknown>;
       const kernels = this.agent.validateKernelStatuses(data.kernels);
       const kernelError = kernels.find(kernel => kernel.error)?.error;
@@ -135,7 +150,9 @@ export class NodeAggregationService {
       if (observedAgent && (!node.agent?.deployed || node.agent.status !== 'running' || node.agent.version !== observedAgent.version)) {
         await this.repository.update(node.id, current => ({ ...current, agent: observedAgent })).catch(() => undefined);
       }
-      const status: NodeStatus = { ...base, online: true, kernels, nodesCount: kernels.reduce((sum,k) => sum+k.nodesCount, 0), ...(lastError ? { lastError } : {}), ...(observedAgent ? { agent: observedAgent } : {}), ...(observedVersion ? { version: observedVersion } : {}), ...(typeof data.uptime === 'number' ? { uptime: data.uptime } : {}), ...(typeof data.mihomoAvailable === 'boolean' ? { mihomoAvailable: data.mihomoAvailable } : {}), ...(typeof data.mihomoVersion === 'string' ? { mihomoVersion: data.mihomoVersion } : {}) };
+      // Agent 已装、可被检测，但尚未纳入监控的内核 = 「打通后可提示纳管」的候选。
+      const adoptableKernels = kernels.filter(kernel => kernel.detected && !kernel.monitored).map(kernel => kernel.type);
+      const status: NodeStatus = { ...base, online: true, kernels, nodesCount: kernels.reduce((sum,k) => sum+k.nodesCount, 0), ...(lastError ? { lastError } : {}), ...(observedAgent ? { agent: observedAgent } : {}), ...(observedVersion ? { version: observedVersion } : {}), ...(typeof data.uptime === 'number' ? { uptime: data.uptime } : {}), ...(typeof data.mihomoAvailable === 'boolean' ? { mihomoAvailable: data.mihomoAvailable } : {}), ...(typeof data.mihomoVersion === 'string' ? { mihomoVersion: data.mihomoVersion } : {}), ...(adoptableKernels.length ? { adoptableKernels } : {}) };
       this.cache.set(node.id, status); return status;
     } catch (error) {
       const message = error instanceof Error && error.name === 'AbortError' ? '请求超时' : `连接失败: ${error instanceof Error ? error.message : String(error)}`;

--- a/packages/core/src/nodes/types.ts
+++ b/packages/core/src/nodes/types.ts
@@ -32,6 +32,8 @@ export interface NodeStatus {
   latency?: number; nodesCount?: number; subscriptionExists?: boolean;
   clashExists?: boolean; mihomoAvailable?: boolean; mihomoVersion?: string; version?: string;
   uptime?: number; agent?: NodeAgentInfo;
+  /** Agent 打通后检测到、但当前未纳入监控的已装内核。前端据此提示用户确认纳管。 */
+  adoptableKernels?: KernelType[];
 }
 export interface ClusterStatus {
   totalNodes: number; onlineNodes: number; totalProxies: number;

--- a/packages/core/test/nodes/services.test.ts
+++ b/packages/core/test/nodes/services.test.ts
@@ -1,5 +1,5 @@
 import { createHmac } from 'node:crypto';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { AgentClient, NodeAggregationService, NodeRepository, type NodeConfig, type StateStore } from '../../src/index.js';
 
 function memoryStore(initial: string | null): StateStore {
@@ -167,6 +167,21 @@ describe('node core services', () => {
     expect(recovered.nodes[0]?.lastError).toContain('offline');
   });
 
+  it('surfaces detected-but-unmonitored kernels as adoption candidates', async () => {
+    const repository = new NodeRepository(memoryStore(`nodes:\n  - id: node-a\n    name: A\n    host: agent.example\n    secret: secret\n    kernels:\n      - type: xray\n    location: HK\n    enabled: true\n`));
+    const reported = [
+      { type: 'sing-box', detected: true, monitored: false, accessible: true, nodesCount: 0, configPaths: [] },
+      { type: 'xray', detected: true, monitored: true, accessible: true, nodesCount: 0, configPaths: ['/etc/xray/config.json'] },
+      { type: 'v2ray', detected: false, monitored: false, accessible: false, nodesCount: 0, configPaths: [] },
+    ];
+    const client = new AgentClient({ fetch: (async () => new Response(
+      JSON.stringify({ data: { version: '1.2.14', kernels: reported, sources: [] } }), { status: 200 },
+    )) as typeof fetch });
+    const status = await new NodeAggregationService(repository, client).getClusterStatus();
+    // sing-box 已装未纳管 → 候选；xray 已纳管、v2ray 未检测 → 排除。
+    expect(status.nodes[0]?.adoptableKernels).toEqual(['sing-box']);
+  });
+
   it('collapses concurrent and rapid cluster-status polls into a single fan-out', async () => {
     const repository = new NodeRepository(memoryStore(`nodes:\n  - id: node-a\n    name: A\n    host: agent.example\n    secret: secret\n    kernels:\n      - type: xray\n    location: HK\n    enabled: true\n`));
     let calls = 0;
@@ -190,9 +205,39 @@ describe('node core services', () => {
     await service.getClusterStatus({ forceRefresh: true });
     expect(calls).toBe(4);
 
-    // TTL 过期后自动重新扇出。
+    // TTL 过期后：stale-while-revalidate 立刻回旧快照，后台再扇出刷新。
     clock += 6_000;
     await service.getClusterStatus();
-    expect(calls).toBe(6);
+    await vi.waitFor(() => expect(calls).toBe(6));
+  });
+
+  it('serves a stale snapshot immediately instead of blocking on a hung fan-out', async () => {
+    const repository = new NodeRepository(memoryStore(`nodes:\n  - id: node-a\n    name: A\n    host: agent.example\n    secret: secret\n    kernels:\n      - type: xray\n    location: HK\n    enabled: true\n`));
+    let calls = 0;
+    let releaseHung: () => void = () => {};
+    const client = new AgentClient({ fetch: (async () => {
+      calls++;
+      // 冷启动的 status()+collectSources() 立刻返回填满缓存；之后的后台刷新挂起，
+      // 模拟一个不可达/慢节点——过期后的读取绝不能被它拖住。
+      if (calls > 2) await new Promise<void>(resolve => { releaseHung = resolve; });
+      return new Response(
+        JSON.stringify({ data: { kernels, sources: [{ kernel: 'xray', url: 'vless://id@example.com:443' }] } }),
+        { status: 200 },
+      );
+    }) as typeof fetch });
+    let clock = 0;
+    const service = new NodeAggregationService(repository, client, undefined, { statusTtlMs: 1_000, now: () => clock });
+
+    await service.getClusterStatus();
+    expect(calls).toBe(2);
+
+    clock += 2_000; // 过期
+    const startedAt = Date.now();
+    const stale = await service.getClusterStatus();
+    // 立刻拿到旧快照，没有等待挂起的后台刷新。
+    expect(stale.totalNodes).toBe(1);
+    expect(Date.now() - startedAt).toBeLessThan(100);
+
+    releaseHung(); // 放行后台刷新，避免测试留下悬挂的 Promise。
   });
 });

--- a/packages/frontend/src/components/cluster/NodeCard.tsx
+++ b/packages/frontend/src/components/cluster/NodeCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Icon } from '@iconify/react';
-import type { NodeStatus } from '@/lib/types';
+import type { NodeKernelConfig, NodeStatus } from '@/lib/types';
+import { useUpdateNodeKernels } from '@/lib/queries/mutations';
 import { NodeDetail } from './NodeDetail';
 import { KernelStatusPills } from './KernelStatus';
 
@@ -24,10 +25,22 @@ export function NodeCard({
   onUninstallAgent,
 }: NodeCardProps) {
   const [expanded, setExpanded] = useState(false);
+  const [adoptDismissed, setAdoptDismissed] = useState(false);
+  const updateKernels = useUpdateNodeKernels();
 
   const needsDeploy = !node.agent?.deployed;
   const isRunning = node.agent?.status === 'running';
   const isDeploying = node.agent?.status === 'deploying';
+
+  // Agent 打通后检测到、但尚未纳入监控的已装内核 → 提示用户确认纳管（点「纳管」即确认）。
+  const adoptable = node.online ? (node.adoptableKernels ?? []) : [];
+  const showAdopt = adoptable.length > 0 && !adoptDismissed;
+
+  const handleAdopt = () => {
+    const byType = new Map<string, NodeKernelConfig>(node.configuredKernels.map((k) => [k.type, k]));
+    for (const type of adoptable) if (!byType.has(type)) byType.set(type, { type });
+    updateKernels.mutate({ nodeId: node.nodeId, kernels: [...byType.values()] });
+  };
 
   return (
     <>
@@ -63,6 +76,35 @@ export function NodeCard({
             configuredKernels={node.configuredKernels}
           />
         </div>
+
+        {showAdopt && (
+          <div
+            className="mb-3 flex items-center justify-between gap-3 rounded-lg px-3 py-2 text-xs"
+            style={{ backgroundColor: 'var(--secondary)', color: 'var(--secondary-foreground)' }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <span className="flex items-center gap-1.5">
+              <Icon icon="ph:magic-wand-bold" className="w-3.5 h-3.5" style={{ color: 'var(--primary)' }} />
+              检测到未纳管内核：{adoptable.join('、')}
+            </span>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={(e) => { e.stopPropagation(); handleAdopt(); }}
+                disabled={updateKernels.isPending}
+                className="flex items-center gap-1 px-2.5 py-1 rounded-md font-medium transition-all active:scale-[0.98] disabled:opacity-60"
+                style={{ backgroundColor: 'var(--primary)', color: 'var(--primary-foreground)' }}>
+                <Icon icon={updateKernels.isPending ? 'ph:spinner-bold' : 'ph:check-bold'} className={`w-3 h-3 ${updateKernels.isPending ? 'animate-spin' : ''}`} />
+                纳管
+              </button>
+              <button
+                onClick={(e) => { e.stopPropagation(); setAdoptDismissed(true); }}
+                className="px-2 py-1 rounded-md font-medium transition-all active:scale-[0.98]"
+                style={{ color: 'var(--muted-foreground)' }}>
+                忽略
+              </button>
+            </div>
+          </div>
+        )}
 
         <div className="flex items-center gap-4 text-sm" style={{ color: 'var(--muted-foreground)' }}>
           <span className="flex items-center gap-1">

--- a/packages/frontend/src/components/cluster/__tests__/cluster-components.test.tsx
+++ b/packages/frontend/src/components/cluster/__tests__/cluster-components.test.tsx
@@ -7,6 +7,7 @@ import { ClusterOverview } from '../ClusterOverview';
 import { NodeCard } from '../NodeCard';
 import { NodeDetail } from '../NodeDetail';
 import { getKernelDisplayStatus } from '../KernelStatus';
+import { renderWithClient } from '@/test/renderWithClient';
 import type { KernelRuntimeStatus, NodeStatus, ClusterStatus } from '@/lib/types';
 
 const runtimeKernels = (
@@ -107,7 +108,7 @@ describe('ClusterOverview', () => {
 
 describe('NodeCard', () => {
   it('renders all kernel labels with their prioritized status', () => {
-    render(<NodeCard node={mockNode} />);
+    renderWithClient(<NodeCard node={mockNode} />);
     expect(screen.getByText('Sing-Box')).toBeDefined();
     expect(screen.getByText('Xray')).toBeDefined();
     expect(screen.getByText('V2Ray')).toBeDefined();
@@ -123,12 +124,12 @@ describe('NodeCard', () => {
         xray: { detected: true, monitored: true, accessible: false, error: '配置文件不可读' },
       }),
     };
-    render(<NodeCard node={inaccessibleNode} />);
+    renderWithClient(<NodeCard node={inaccessibleNode} />);
     expect(screen.getByText('配置不可访问')).toBeDefined();
   });
 
   it('renders three unknown pills for an offline DTO with an empty runtime array', () => {
-    render(<NodeCard node={mockOfflineNode} />);
+    renderWithClient(<NodeCard node={mockOfflineNode} />);
     expect(screen.getAllByText('未知')).toHaveLength(3);
     expect(screen.getAllByTestId('kernel-status-type').map(element => element.textContent))
       .toEqual(['Sing-Box', 'Xray', 'V2Ray']);
@@ -140,14 +141,14 @@ describe('NodeCard', () => {
       ...mockNode,
       kernels: [mockNode.kernels[2], mockNode.kernels[0]],
     };
-    render(<NodeCard node={partialNode} />);
+    renderWithClient(<NodeCard node={partialNode} />);
     expect(screen.getAllByTestId('kernel-status-type').map(element => element.textContent))
       .toEqual(['Sing-Box', 'Xray', 'V2Ray']);
     expect(screen.getByText('未知')).toBeDefined();
   });
 
   it('expands to show detail on click', () => {
-    render(<NodeCard node={mockNode} />);
+    renderWithClient(<NodeCard node={mockNode} />);
     fireEvent.click(screen.getByRole('heading', { name: '新加坡' }));
     expect(screen.getByRole('dialog', { name: '新加坡' })).toBeDefined();
   });

--- a/packages/frontend/src/components/cluster/__tests__/node-adopt-kernels.test.tsx
+++ b/packages/frontend/src/components/cluster/__tests__/node-adopt-kernels.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NodeCard } from '../NodeCard'
+import type { NodeStatus } from '@/lib/types'
+
+const api = vi.hoisted(() => ({ updateNodeKernels: vi.fn() }))
+vi.mock('@/lib/api', () => ({ apiService: api }))
+
+function renderCard(node: NodeStatus) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  return render(<QueryClientProvider client={client}><NodeCard node={node} /></QueryClientProvider>)
+}
+
+const baseNode: NodeStatus = {
+  nodeId: 'node-adopt', name: '东京', location: 'JP', online: true,
+  configuredKernels: [{ type: 'xray' }],
+  kernels: [
+    { type: 'sing-box', detected: true, monitored: false, accessible: true, nodesCount: 0, configPaths: [] },
+    { type: 'xray', detected: true, monitored: true, accessible: true, nodesCount: 4, configPaths: ['/etc/xray/config.json'] },
+    { type: 'v2ray', detected: false, monitored: false, accessible: false, nodesCount: 0, configPaths: [] },
+  ],
+  agent: { deployed: true, version: '1.0.0', status: 'running', lastDeploy: '' },
+  adoptableKernels: ['sing-box'],
+}
+
+describe('NodeCard kernel adoption prompt', () => {
+  beforeEach(() => {
+    api.updateNodeKernels.mockReset()
+    api.updateNodeKernels.mockResolvedValue({ success: true, data: {}, timestamp: '' })
+  })
+
+  it('adopts detected-but-unmonitored kernels, merging into the configured set on confirm', async () => {
+    renderCard(baseNode)
+    expect(screen.getByText(/检测到未纳管内核/)).toBeDefined()
+
+    fireEvent.click(screen.getByRole('button', { name: '纳管' }))
+    await waitFor(() => expect(api.updateNodeKernels).toHaveBeenCalledTimes(1))
+    // 合并既有 xray 与新纳管的 sing-box，不重复。
+    expect(api.updateNodeKernels).toHaveBeenCalledWith('node-adopt', [{ type: 'xray' }, { type: 'sing-box' }])
+  })
+
+  it('hides the prompt on ignore without calling the API', () => {
+    renderCard(baseNode)
+    fireEvent.click(screen.getByRole('button', { name: '忽略' }))
+    expect(screen.queryByText(/检测到未纳管内核/)).toBeNull()
+    expect(api.updateNodeKernels).not.toHaveBeenCalled()
+  })
+
+  it('shows no prompt when there is nothing to adopt', () => {
+    renderCard({ ...baseNode, adoptableKernels: [] })
+    expect(screen.queryByText(/检测到未纳管内核/)).toBeNull()
+  })
+
+  it('shows no prompt while the node is offline', () => {
+    renderCard({ ...baseNode, online: false })
+    expect(screen.queryByText(/检测到未纳管内核/)).toBeNull()
+  })
+})

--- a/packages/frontend/src/lib/types.ts
+++ b/packages/frontend/src/lib/types.ts
@@ -88,6 +88,8 @@ export interface NodeStatus {
   version?: string;
   uptime?: number;
   agent?: NodeAgentInfo;
+  /** Agent 打通后检测到、但当前未纳入监控的已装内核，供前端提示用户确认纳管。 */
+  adoptableKernels?: KernelType[];
 }
 
 /** Cluster aggregate status */


### PR DESCRIPTION
## 问题
`GET /api/cluster/status` 仍偶发 `Request timed out`(前端 30s)。2s 缓存对间隔 >2s 的轮询无效——每次都跑一次实时扇出,单个慢/不可达节点即可拖满整条请求。

## 修复 #1 — 状态端点绝不阻塞
- **stale-while-revalidate**:有旧快照即刻返回,过期只丢一个后台刷新,请求线程绝不等待实时扇出。
- 扇出用 **5s 短探测超时**(独立于部署/日志的 10s 默认)。冷启动最坏 5s 兜底,之后永不超时。
- in-flight 去重:并发轮询复用同一次扇出。

## 新功能 #2 — 已装内核默认纳管
- 后端透出 `NodeStatus.adoptableKernels` = agent 上报 `detected && !monitored` 的内核。
- 前端 `NodeCard` agent 打通后弹提示条「检测到未纳管内核: X — 纳管/忽略」;点**纳管**合并进监控集,走既有 `updateNodeKernels`(自动重配运行中 agent)。
- 范围:运行中 agent 打通 + 手动/bootstrap 安装(SSH 部署原逻辑不动)。按「弹确认再纳管」交互。

## 验证
- core 54 · cli 163 · frontend 65 测全绿
- `typecheck` / `lint` 净;graphify 已更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)