### PR TITLE
Revert version-fallback bump to keep main green

### DIFF
--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -8,7 +8,7 @@ import { formatLocalNodeConfiguration, type LocalNodeConfigurationService } from
 import { formatDashboardDaemonStatus, type DashboardDaemonAction } from './dashboard/commands.js';
 import type { DashboardDaemonStatus } from './dashboard/systemd.js';
 
-export const CLI_VERSION = process.env.MIOBRIDGE_BUILD_VERSION ?? '1.2.15';
+export const CLI_VERSION = process.env.MIOBRIDGE_BUILD_VERSION ?? '1.2.12';
 
 export interface CliCore {
   updateSubscription(): Promise<UpdateResult>;


### PR DESCRIPTION
PR #32 合并时携带了 `chore(cli): bump default version fallback to 1.2.15`(7c64f2a),但 `Verify release contracts` 步不注入 `MIOBRIDGE_BUILD_VERSION`,`headless.test.ts:67` 硬编码期望 `version:'1.2.12'`,导致 main 测试挂。

本 PR 合入回退 d1ce6ab,使源码兜底与该硬编码测试重新一致。真实发布版本仍由 tag 在 release 时注入,不受影响(v1.2.15 已按此发布)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)