### PR TITLE
fix(core): Clash gen without mihomo; feat: health-check kernel adoption

### DIFF
--- a/packages/core/src/artifacts/artifactService.ts
+++ b/packages/core/src/artifacts/artifactService.ts
@@ -102,8 +102,10 @@ export class ArtifactService {
     let clashError: string | undefined;
     let clashContent: string | undefined;
     try {
-      if (!await this.options.clash.checkHealth()) throw new Error('Mihomo服务未运行或不可访问');
       if (!clashInput.content) throw new Error('没有可用于生成 Clash 配置的代理来源');
+      // Clash 产物是纯解析 + 模板生成，并不依赖 mihomo；mihomo 只在可用时做一次校验。
+      // 故 mihomo 不可用时照常生成并写盘（跳过校验），仅记一条警告——绝不因缺 mihomo 丢弃这次更新。
+      if (!await this.options.clash.checkHealth()) warnings.push('mihomo 不可用：已生成 Clash 配置但跳过校验');
       clashContent = await this.options.clash.convertToClashByContent(clashInput.content);
       if (!clashContent || !clashContent.includes('proxies:')) throw new Error('转换结果不包含有效的代理配置');
       clashGenerated = true;

--- a/packages/core/src/kernels/mihomoAdapter.ts
+++ b/packages/core/src/kernels/mihomoAdapter.ts
@@ -209,7 +209,9 @@ export class MihomoAdapter {
   }
   private async validate(config: string): Promise<void> {
     const executable = this.executable ?? await this.findExecutable();
-    if (!executable) throw new Error('mihomo 不可用，无法验证 Clash 配置');
+    // 校验是可选增强，不是生成的前置：mihomo 不存在就跳过校验、保留已生成的配置，
+    // 而非让整个 Clash 生成失败。mihomo 存在却校验不过（配置真非法）才向上抛错。
+    if (!executable) { this.options.logger.warn('mihomo 不可用，跳过 Clash 配置校验'); return; }
     const configDir = this.options.paths.managedPath('mihomo');
     const temp = join(configDir, 'temp-config.yaml');
     await this.options.fs.mkdir(configDir);

--- a/packages/core/test/artifacts-core.test.ts
+++ b/packages/core/test/artifacts-core.test.ts
@@ -61,6 +61,21 @@ describe('ArtifactService', () => {
     expect(await readFile(join(config.staticDir, 'subscription.txt'), 'utf8')).toBe('old-subscription');
   });
 
+  it('writes the Clash config even when mihomo is unavailable, flagging it as unvalidated', async () => {
+    const { config } = await setup();
+    const usable = 'vless://id@usable.example:443#usable';
+    const service = new ArtifactService({ config, logger,
+      local: { isAvailable: async () => true, extractNodeUrls: async () => [usable] },
+      remote: { collectRemoteNodeSources: async () => ({ sources: [], errors: [] }) },
+      clash: { checkHealth: async () => false, convertToClashByContent: async content => `proxies:\n${content}\n` },
+    });
+    const result = await service.updateSubscription();
+    // mihomo 只做可选校验；缺席时仍生成并写盘，只带一条「未校验」警告。
+    expect(result.clashGenerated).toBe(true);
+    expect(result.warnings ?? []).toContain('mihomo 不可用：已生成 Clash 配置但跳过校验');
+    expect(await readFile(join(config.staticDir, 'clash.yaml'), 'utf8')).toContain('proxies:');
+  });
+
   it('publishes every unique kernel source from multiple managed nodes into all three artifacts', async () => {
     const { config } = await setup();
     const sources = ['node-a', 'node-b'].flatMap((nodeId, nodeIndex) =>

--- a/packages/frontend/src/components/cluster/NodeDetail.tsx
+++ b/packages/frontend/src/components/cluster/NodeDetail.tsx
@@ -8,7 +8,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import type { NodeStatus } from '@/lib/types';
+import type { NodeKernelConfig, NodeStatus } from '@/lib/types';
+import { useUpdateNodeKernels } from '@/lib/queries/mutations';
 import { KernelRuntimeDetails } from './KernelStatus';
 
 interface NodeDetailProps {
@@ -28,6 +29,22 @@ export function NodeDetail({
 }: NodeDetailProps) {
   const [updating, setUpdating] = useState(false);
   const [checking, setChecking] = useState(false);
+  // 健康检查是「重新征询纳管」的显式入口：每次点都重开，绕过卡片提示条那一次性的忽略，
+  // 让 agent 部署/刷新后仍能纳管过去经其他途径安装的内核。
+  const [promptAdopt, setPromptAdopt] = useState(false);
+  const updateKernels = useUpdateNodeKernels();
+
+  const adoptable = node.online ? (node.adoptableKernels ?? []) : [];
+  const showAdopt = promptAdopt && adoptable.length > 0;
+
+  const handleAdopt = () => {
+    const byType = new Map<string, NodeKernelConfig>(node.configuredKernels.map((k) => [k.type, k]));
+    for (const type of adoptable) if (!byType.has(type)) byType.set(type, { type });
+    updateKernels.mutate(
+      { nodeId: node.nodeId, kernels: [...byType.values()] },
+      { onSuccess: () => setPromptAdopt(false) },
+    );
+  };
 
   const formatUptime = (s?: number) => {
     if (!s && s !== 0) return '-';
@@ -51,6 +68,8 @@ export function NodeDetail({
     setChecking(true);
     try {
       await onHealthCheck(node.nodeId);
+      // 刷新已带回最新 adoptableKernels；显式开启纳管征询（有候选才真正展示）。
+      setPromptAdopt(true);
     } finally {
       setChecking(false);
     }
@@ -166,6 +185,36 @@ export function NodeDetail({
                 </span>
               </InfoRow>
             )}
+          </div>
+        </div>
+      )}
+
+      {showAdopt && (
+        <div
+          className="mt-4 flex items-center justify-between gap-3 rounded-lg px-3 py-2 text-sm"
+          style={{ backgroundColor: 'var(--secondary)', color: 'var(--secondary-foreground)' }}
+        >
+          <span className="flex items-center gap-1.5">
+            <Icon icon="ph:magic-wand-bold" className="w-4 h-4" style={{ color: 'var(--primary)' }} />
+            检测到未纳管内核：{adoptable.join('、')}
+          </span>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleAdopt}
+              disabled={updateKernels.isPending}
+              className="flex items-center gap-1 px-3 py-1 rounded-md font-medium transition-all active:scale-[0.98] disabled:opacity-60"
+              style={{ backgroundColor: 'var(--primary)', color: 'var(--primary-foreground)' }}
+            >
+              <Icon icon={updateKernels.isPending ? 'ph:spinner-bold' : 'ph:check-bold'} className={`w-3.5 h-3.5 ${updateKernels.isPending ? 'animate-spin' : ''}`} />
+              纳管
+            </button>
+            <button
+              onClick={() => setPromptAdopt(false)}
+              className="px-3 py-1 rounded-md font-medium transition-all active:scale-[0.98]"
+              style={{ color: 'var(--muted-foreground)' }}
+            >
+              取消
+            </button>
           </div>
         </div>
       )}

--- a/packages/frontend/src/components/cluster/__tests__/cluster-components.test.tsx
+++ b/packages/frontend/src/components/cluster/__tests__/cluster-components.test.tsx
@@ -158,7 +158,7 @@ describe('NodeDetail', () => {
   const onClose = vi.fn();
 
   it('shows type, version, config paths, proxy count, and error for each kernel', () => {
-    render(<NodeDetail node={mockNode} isOpen onClose={onClose} />);
+    renderWithClient(<NodeDetail node={mockNode} isOpen onClose={onClose} />);
     const dialog = screen.getByRole('dialog', { name: '新加坡' });
     expect(within(dialog).getByText('Sing-Box')).toBeDefined();
     expect(within(dialog).getByText('1.11.0')).toBeDefined();
@@ -169,7 +169,7 @@ describe('NodeDetail', () => {
   });
 
   it('renders kernel details as unknown while a node is offline', () => {
-    render(<NodeDetail node={mockOfflineNode} isOpen onClose={onClose} />);
+    renderWithClient(<NodeDetail node={mockOfflineNode} isOpen onClose={onClose} />);
     expect(screen.getAllByText('未知')).toHaveLength(3);
     expect(screen.getByRole('region', { name: 'Sing-Box 内核详情' })).toBeDefined();
     expect(screen.getByRole('region', { name: 'Xray 内核详情' })).toBeDefined();

--- a/packages/frontend/src/components/cluster/__tests__/node-detail-adopt.test.tsx
+++ b/packages/frontend/src/components/cluster/__tests__/node-detail-adopt.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NodeDetail } from '../NodeDetail'
+import type { NodeStatus } from '@/lib/types'
+
+const api = vi.hoisted(() => ({ updateNodeKernels: vi.fn() }))
+vi.mock('@/lib/api', () => ({ apiService: api }))
+// iconify 在 jsdom 里异步拉取图标，测试卸载后其 timer 仍 fire → unhandled error 噪音；
+// 图标非本测试关注点，stub 掉即可。
+vi.mock('@iconify/react', () => ({ Icon: () => null }))
+
+function renderDetail(node: NodeStatus, onHealthCheck?: (id: string) => Promise<unknown>) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <NodeDetail node={node} isOpen onClose={vi.fn()} onHealthCheck={onHealthCheck} />
+    </QueryClientProvider>,
+  )
+}
+
+const baseNode: NodeStatus = {
+  nodeId: 'node-detail-adopt', name: '首尔', location: 'KR', online: true,
+  configuredKernels: [{ type: 'xray' }],
+  kernels: [
+    { type: 'sing-box', detected: true, monitored: false, accessible: true, nodesCount: 0, configPaths: [] },
+    { type: 'xray', detected: true, monitored: true, accessible: true, nodesCount: 4, configPaths: ['/etc/xray/config.json'] },
+    { type: 'v2ray', detected: false, monitored: false, accessible: false, nodesCount: 0, configPaths: [] },
+  ],
+  agent: { deployed: true, version: '1.0.0', status: 'running', lastDeploy: '' },
+  adoptableKernels: ['sing-box'],
+}
+
+describe('NodeDetail health-check kernel adoption prompt', () => {
+  beforeEach(() => {
+    api.updateNodeKernels.mockReset()
+    api.updateNodeKernels.mockResolvedValue({ success: true, data: {}, timestamp: '' })
+  })
+
+  it('does not prompt until the health-check button is pressed', () => {
+    renderDetail(baseNode, vi.fn().mockResolvedValue(undefined))
+    // 已有可纳管内核，但健康检查前不主动弹，避免打断浏览。
+    expect(screen.queryByText(/检测到未纳管内核/)).toBeNull()
+  })
+
+  it('prompts adoption after a manual health check and merges on confirm', async () => {
+    const onHealthCheck = vi.fn().mockResolvedValue(undefined)
+    renderDetail(baseNode, onHealthCheck)
+
+    fireEvent.click(screen.getByRole('button', { name: '健康检查' }))
+    await waitFor(() => expect(onHealthCheck).toHaveBeenCalledWith('node-detail-adopt'))
+    await screen.findByText(/检测到未纳管内核/)
+
+    fireEvent.click(screen.getByRole('button', { name: '纳管' }))
+    await waitFor(() => expect(api.updateNodeKernels).toHaveBeenCalledTimes(1))
+    // 合并既有 xray 与新纳管的 sing-box，不重复。
+    expect(api.updateNodeKernels).toHaveBeenCalledWith('node-detail-adopt', [{ type: 'xray' }, { type: 'sing-box' }])
+  })
+
+  it('hides the prompt on cancel without calling the API', async () => {
+    renderDetail(baseNode, vi.fn().mockResolvedValue(undefined))
+    fireEvent.click(screen.getByRole('button', { name: '健康检查' }))
+    await screen.findByText(/检测到未纳管内核/)
+
+    fireEvent.click(screen.getByRole('button', { name: '取消' }))
+    expect(screen.queryByText(/检测到未纳管内核/)).toBeNull()
+    expect(api.updateNodeKernels).not.toHaveBeenCalled()
+  })
+
+  it('shows no prompt when there is nothing to adopt', async () => {
+    renderDetail({ ...baseNode, adoptableKernels: [] }, vi.fn().mockResolvedValue(undefined))
+    fireEvent.click(screen.getByRole('button', { name: '健康检查' }))
+    await waitFor(() => expect(screen.queryByText(/检测到未纳管内核/)).toBeNull())
+  })
+})


### PR DESCRIPTION
两处改动。

## fix(core): Clash 生成不再依赖 mihomo
Clash 配置是纯解析 + 模板生成，mihomo 本只用于「可用时自动验证」。但 `artifactService` 把整份生成 gate 在 mihomo 健康上、`mihomoAdapter.validate()` 在 mihomo 缺席时抛错——于是任何没跑 mihomo 的主机上，生成步静默失败、磁盘旧 clash.yaml 原样保留、任务仅标「部分成功」，用户对着旧规则怎么更新都不变。

解耦生成与校验：只要解析出有效节点就生成并写盘；mihomo 可用才校验，不可用则跳过（带警告）。mihomo 在、配置真非法时仍失败。

## feat(frontend): 健康检查重新征询纳管
NodeCard 的纳管提示条可忽略且一次性，agent 部署 + 刷新后，经其他途径（手动/apt）安装的内核再无纳管入口。将 NodeDetail 手动「健康检查」按钮接为显式重新征询：点后浮现检测到但未纳管的内核供纳管，绕过卡片的一次性忽略。

## 验证
- core 55 · cli 163 · frontend 69 全绿
- typecheck · lint 净

🤖 Generated with [Claude Code](https://claude.com/claude-code)