### PR TITLE
fix(core): bound Agent requests with an independent timeout

### DIFF
--- a/packages/core/src/nodes/agentClient.ts
+++ b/packages/core/src/nodes/agentClient.ts
@@ -33,17 +33,37 @@ export class AgentClient {
     return { 'X-Node-Id': node.id, 'X-Timestamp': timestamp, 'X-Signature': signature };
   }
 
+  /**
+   * 超时必须由调用方这一侧独立保证，不能只依赖 AbortController：节点不可达时 TCP 连接
+   * 停在 SYN-SENT，abort() 在部分运行时并不会拆掉它，promise 要等内核放弃（约 135s）才 settle。
+   * 因此这里把 fetch 和一个定时器 race —— abort 照发（好让 socket 最终释放），但调用方
+   * 到点就拿到「请求超时」，任何一个失联节点都不会再拖住整条扇出。
+   */
   async get(node: NodeConfig, path: string, timeoutMs = this.timeoutMs): Promise<unknown> {
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const expired = new Promise<never>((_, reject) => {
+      timeout = setTimeout(() => {
+        controller.abort();
+        // status()/collectSources() 按 name === 'AbortError' 把失败翻译成「请求超时」，沿用同一形状。
+        const error = new Error('请求超时');
+        error.name = 'AbortError';
+        reject(error);
+      }, timeoutMs);
+    });
     try {
-      const port = node.port ?? node.agent?.port ?? 3001;
-      const response = await this.fetcher(`http://${node.host}:${port}${path}`, {
-        method: 'GET', headers: { 'Content-Type': 'application/json', ...this.sign(node, 'GET', path) }, signal: controller.signal,
-      });
-      if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      return response.json();
+      return await Promise.race([this.fetchJson(node, path, controller.signal), expired]);
     } finally { clearTimeout(timeout); }
+  }
+
+  private async fetchJson(node: NodeConfig, path: string, signal: AbortSignal): Promise<unknown> {
+    const port = node.port ?? node.agent?.port ?? 3001;
+    const response = await this.fetcher(`http://${node.host}:${port}${path}`, {
+      method: 'GET', headers: { 'Content-Type': 'application/json', ...this.sign(node, 'GET', path) }, signal,
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    // await 而不是直接 return：否则 get() 的 finally 会在读 body 之前就清掉定时器，body 读取将不再有超时。
+    return await response.json();
   }
 
   validateKernelStatuses(value: unknown): KernelRuntimeStatus[] {

--- a/packages/core/test/nodes/services.test.ts
+++ b/packages/core/test/nodes/services.test.ts
@@ -22,6 +22,14 @@ describe('node core services', () => {
     expect(client.sign({ ...node, host: '127.0.0.1' }, 'GET', '/api/status')).toEqual({});
   });
 
+  // 真实故障：节点不可达时 TCP 连接停在 SYN-SENT，内核要 ~135s 才放弃，
+  // 而 abort() 在部分运行时并不会拆掉这条连接。只挂 AbortController 的实现
+  // 会把调用方一起拖住 135s，订阅预检因此长时间不返回。
+  it('gives up on an unreachable Agent even when abort does not settle the request', async () => {
+    const client = new AgentClient({ timeoutMs: 20, fetch: (() => new Promise(() => {})) as unknown as typeof fetch });
+    await expect(client.get(node, '/api/status')).rejects.toMatchObject({ name: 'AbortError', message: '请求超时' });
+  });
+
   it('reads nodes.yaml directly and filters disabled nodes', async () => {
     const repository = new NodeRepository(memoryStore(`nodes:\n  - id: node-a\n    name: A\n    host: example\n    secret: secret\n    kernels:\n      - type: xray\n    location: HK\n    enabled: true\n  - id: off\n    name: Off\n    host: off\n    secret: x\n    kernels: []\n    location: HK\n    enabled: false\n`));
     expect((await repository.list()).map(n => n.id)).toEqual(['node-a']);

--- a/packages/frontend/src/pages/subscription.tsx
+++ b/packages/frontend/src/pages/subscription.tsx
@@ -3,7 +3,6 @@ import { useQueryClient } from '@tanstack/react-query'
 import { Icon } from '@iconify/react'
 import { Link } from 'react-router-dom'
 import { toast } from 'sonner'
-import { apiService } from '@/lib/api'
 import { streamServerEvents } from '@/lib/sse'
 import {
   queryKeys, useArtifacts, useClusterStatus, useRetrySubscriptionJob, useStartSubscriptionJob,
@@ -42,7 +41,9 @@ export default function SubscriptionPage() {
   const queryClient = useQueryClient()
   const pollOptions = { refetchInterval: 5000, refetchIntervalInBackground: false } as const
   const clusterQuery = useClusterStatus(pollOptions)
-  const preflightQuery = useSubscriptionPreflight(pollOptions)
+  // 预检是一次对全部节点的实时扇出（还会在本机 spawn sing-box），耗时远超 5s 轮询间隔，
+  // 按 5s 轮它只会让请求互相叠压。它不是实时指标，30s 足够。
+  const preflightQuery = useSubscriptionPreflight({ ...pollOptions, refetchInterval: 30000 })
   const jobsQuery = useSubscriptionJobs(pollOptions)
   const artifactsQuery = useArtifacts()
   const statusQuery = useStatus()
@@ -87,8 +88,8 @@ export default function SubscriptionPage() {
   const generate = useCallback(async () => {
     setLoading(true); setError(null)
     try {
-      const check = await apiService.preflightSubscription()
-      if (!check.success || !check.data?.ready) throw new Error(check.data?.blockingErrors.join('；') || message(check.error, '没有可读来源'))
+      // 不在这里再预检一次：服务端 start() 本身就会跑预检并把 blockingErrors 作为错误抛回来。
+      // 多这一次调用只是把一次完整的节点扇出（不可达节点尤其慢）串在点击和任务创建之间。
       const response = await startJob.mutateAsync()
       if (!response.success) throw new Error(message(response.error, '创建订阅任务失败'))
       toast.success('订阅任务已持久化并进入队列', { description: response.data?.jobId })
@@ -136,7 +137,14 @@ export default function SubscriptionPage() {
         description="生成、健康状态与定时策略。产物的预览与下载在总览页。"
         actions={(
           <button onClick={generate} disabled={loading || !preflight?.ready || activeJobs.length > 0} className="mb-pill-btn primary">
-            <Icon icon="ph:play-circle-light" style={{ fontSize: 15 }} />{loading ? '创建中…' : activeJobs.length ? '生成任务执行中' : '创建生成任务'}
+            {/* 按钮被 preflight.ready 把着，预检没回来之前它是禁用的。标签必须说明原因，
+                否则用户只会看到一个「创建生成任务」按钮点了没反应。 */}
+            <Icon icon="ph:play-circle-light" style={{ fontSize: 15 }} />
+            {loading ? '创建中…'
+              : activeJobs.length ? '生成任务执行中'
+              : preflightQuery.isPending ? '预检中…'
+              : !preflight?.ready ? '预检未通过'
+              : '创建生成任务'}
           </button>
         )}
       />

--- a/packages/frontend/src/pages/subscription.tsx
+++ b/packages/frontend/src/pages/subscription.tsx
@@ -143,6 +143,7 @@ export default function SubscriptionPage() {
             {loading ? '创建中…'
               : activeJobs.length ? '生成任务执行中'
               : preflightQuery.isPending ? '预检中…'
+              : preflightQuery.isError ? '预检失败'
               : !preflight?.ready ? '预检未通过'
               : '创建生成任务'}
           </button>


### PR DESCRIPTION
## 问题

订阅页「创建生成任务」按钮点击无效。

按钮由 `disabled={!preflight?.ready}` 把守，而 `POST /api/subscription-jobs/preflight` 实测耗时 **134.7s / 135.1s / 135.1s**（三次一致）。这段时间里按钮是禁用的，标签却仍写着「创建生成任务」，点击被静默吞掉。

## 根因

节点 htsong（有意保留的「端口不通」样本）的 3001 被防火墙 DROP 而非 REJECT，TCP 连接停在 SYN-SENT。`AgentClient.get` 只用 `AbortController` 约束请求，而 abort() 在部分运行时并不会拆掉这条 socket，于是 promise 要等内核重试耗尽才 settle（`tcp_syn_retries=6` ≈ 135s）。

`collectRemoteNodeSources` 用 `Promise.all` 并发扇出，整条预检因此被最慢的那个节点拖到 135s。

证据：
- `curl http://206.119.168.196:3001/api/status` → `connect=0.000000s total=135.029000s`
- `ss -tnp` 显示 dashboard 进程上 8 条滞留的 SYN-SENT socket
- 相邻端口 3000/3002/9999 同样 timeout，而 22/80/443 是 refused（RST）→ 白名单外一律 DROP

预检的**判定**本来就不阻塞（`blockingErrors` 仅在 `sources.length === 0` 时产生，单节点失败只入 `warnings`，`ready` 仍为 true）。阻塞的一直是时延。

## 改动

- `agentClient.ts`：把 fetch 和定时器 race，到点即以 `AbortError`/`请求超时` 拒绝（abort 照发，好让 socket 最终释放）。body 读取改为 `await`，否则 `finally` 会在读 body 之前清掉定时器。
- `subscription.tsx`：删掉点击时那次重复预检（服务端 `start()` 本就会跑预检并把 `blockingErrors` 抛回）；预检轮询 5s 改 30s；按钮标签区分「预检中…／预检未通过／创建生成任务」。
- `services.test.ts`：先写的失败测试——fetch 永不 settle 时，`get()` 仍须在 timeoutMs 后拒绝。

最坏情况从 135s 降到 10s，失联节点记一条 warning，订阅照常生成。

## 测试

`core 75` / `cli 125` / `frontend 46` 全过，`typecheck` 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)